### PR TITLE
longdesc cr report: compress tables further; incorporate review comments

### DIFF
--- a/html-longdesc/cr-report.html
+++ b/html-longdesc/cr-report.html
@@ -3,7 +3,7 @@
   <head>
     <meta content="text/html; charset=utf-8" http-equiv="content-type">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>longdesc test-results</title>
+    <title>W3C CR: Image Description Test Results</title>
     <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-WD.css" />
     <style><!--
       table { border-collapse:collapse; }
@@ -21,13 +21,13 @@
 
     <div class="head">
       <p><a href="http://www.w3.org/"><img alt="W3C" src="http://www.w3.org/Icons/w3c_home"
+	  longdesc="w3clogo-longdesc.txt"
 	  height="48"
 	  width="72"></a>
       </p>
 
-    <h1 class="title" id="title"><acronym>W3C</acronym> 
-      HTML5 Image Description Extension (longdesc)</h1>
-    <h2>Candidate Recommendation Implementation Report, 4 September 2014</h2>
+    <h1 class="title" id="title">Implementation Report</h1>
+    <h2><acronym>W3C</acronym> HTML5 Image Description Extension (longdesc), 4 September 2014</h2>
     <dl>
       <dt>This version:</dt>
       <dd><a href="http://w3c.github.io/test-results/html-longdesc/cr-report.html">http://w3c.github.io/test-results/html-longdesc/cr-report.html</a></dd>
@@ -220,292 +220,308 @@
     <section id="mfresults-discovery">
     <h2 id="muft">Table 1: Multi-function tests - discovery, availability to the
       user</h2>
-    <table border="1">
+    <table border="1" class="widetable">
       <tbody>
         <tr>
           <th rowspan="2" scope="col">Test</th>
-          <th colspan="2" scope="col">Yandex 1.7 + <a href="https://chrome.google.com/webstore/detail/longdesc/haohljalgapbacpkfefnmhiadanhejmb">"Longdesc"
-              extension</a>, MacOS</th>
+          <th colspan="2" scope="col">Yandex 1.7 + <a href="https://chrome.google.com/webstore/detail/longdesc/haohljalgapbacpkfefnmhiadanhejmb">long&shy;desc
+              exten&shy;sion</a>, MacOS</th>
           <th colspan="2" scope="col">FF 23, MacOS 10.7.5</th>
           <th colspan="2" scope="col">FF 23+ JAWS 15, Win</th>
           <th colspan="2" scope="col">IE10, JAWS 15, Win</th>
           <th colspan="2" scope="col">FF 27 Aviewer, Win</th>
-          <th colspan="2" scope="col">FF23 + NVDA2013.2, Win</th>
-          <th colspan="2" scope="col">IE10 + NVDA2013.2, Win</th>
+          <th colspan="2" scope="col">FF23 + NVDA 2013.2, Win</th>
+          <th colspan="2" scope="col">IE10 + NVDA 2013.2, Win</th>
           <th colspan="2" scope="col">Opera 12.15, MacOS 10.7.5</th>
           <th colspan="2" scope="col">iCab 5.1, MacOS 10.7.5</th>
           <th colspan="2" scope="col">Orca, FF 32, Linux</th>
         </tr>
         <tr>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <th scope="col">Access</th>
-          <th scope="col">Discover</th>
-          <!--* Orca *--> <th scope="col">Access</th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">—</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <th scope="col"><span title="Access">Acc.</span></th>
+          <th scope="col"><span title="Discovery">Disc.</span></th>
+          <!--* Orca *--> <th scope="col"><span title="Access">Acc.</span></th>
+        </tr>
+        <tr valign="top">
+          <th scope="row" valign="top">Comments</th>
+	  <td colspan="2"><a href="#fna1" title="Discovery is achieved by user-configurable highlighting.">[1]</a></td>
+          <td colspan="2"><a href="#fna2" title="Access to the description is poor, copy/paste URL">[2]</a></td>
+          <td colspan="2"><br>
+          </td>
+          <td colspan="2"><br>
+          </td>
+          <td colspan="2"><br>
+          </td>
+          <td colspan="2"><br>
+          </td>
+          <td colspan="2"><br>
+          </td>
+          <td colspan="2"><a href="#fna3" title="Discovery weak, longdesc in context menu...">[3]</a></td>
+          <td colspan="2"><a href="#fna4" title="Data:uri images fail to render properly. Not a longdesc bug.">[4]</a></td>
+	  <td colspan="2"><a href="#fnae" title="Gecko does not expose longdesc when image is empty (Gecko bug)">[5]</a></td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-data-uri-description.html">ext
               img - data:URI desc</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span> </td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/empty-image-external-description.html">empty
               img - external desc</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
           <td class="fail">N/A</td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-external-description.html">ext
               img - ext desc</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
-          <td class="fail">PASS</td>
+          <td class="fail"><span title="pass">✔</span></td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-internal-description.html">ext
               img - internal desc</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
-          <td class="fail">fail</td>
+          <td class="fail"><span title="fail">✕</span></td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-external-description-fragment-girt-by-spaces.html">ext
               img - ext desc fragment with spaces</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
           <td><br>
           </td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
-          <td class="fail">fail</td>
+          <td class="fail"><span title="fail">✕</span></td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-external-description-fragment.html">ext
               img - ext desc fragment</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
-          <td class="fail">fail</td>
+          <td class="fail"><span title="fail">✕</span></td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-with-absolute-base-external-description.html">ext
               img - ext desc with absolute base</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="fail">FAIL</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-with-relative-base-external-description.html">ext
               img - ext desc with relative base</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
           <td><br>
           </td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
         </tr>
         <tr>
-          <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/iframe-discoverability.html">img
+          <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/iframe-Discability.html">img
               in <code>&lt;iframe&gt;</code></a></th>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <td><br>
           </td>
           <td><br>
           </td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="fail">FAIL</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="fail"><span title="fail">✕</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
         </tr>
-        <tr>
-          <th scope="row">Comments</th>
-          <td colspan="2">Discovery is achieved by user-configurable&nbsp;
-            highlighting.</td>
-          <td colspan="2">Access to the description is poor. You can get the URL
-            of the longdesc, then copy it and paste it into a tab</td>
+        <tr valign="top">
+          <th scope="row" valign="top">Comments</th>
+	  <td colspan="2"><a href="#fna1" title="Discovery is achieved by user-configurable highlighting.">[1]</a></td>
+          <td colspan="2"><a href="#fna2" title="Access to the description is poor, copy/paste URL">[2]</a></td>
           <td colspan="2"><br>
           </td>
           <td colspan="2"><br>
@@ -516,42 +532,54 @@
           </td>
           <td colspan="2"><br>
           </td>
-          <td colspan="2">Discovery is weak - there is a longdesc option in the
-            context menu when there is a longdesc available</td>
-          <td colspan="2">Data:uri images fail to render properly. (This is not
-            a <code>longdesc</code> bug).</td>
-          <td colspan="2">N/A: For tests where the image is empty, Gecko fails
-            to expose the presence of the longdesc via ATK or "to all users" and
-            hence Orca doesn't see it; this is a Gecko bug, not an Orca or
-            longdesc bug.<br>
-            FAIL: For tests where the description is found in a fragment, Orca
-            does not present the page starting with that fragment. It presents
-            the page starting from the top. Note, this is a Gecko bug, not an
-            Orca bug.</td>
+          <td colspan="2"><a href="#fna3" title="Discovery weak, longdesc in context menu...">[3]</a></td>
+          <td colspan="2"><a href="#fna4" title="Data:uri images fail to render properly. Not a longdesc bug.">[4]</a></td>
+	  <td colspan="2"><a href="#fnae" title="Gecko does not expose longdesc when image is empty (Gecko bug)">[5]</a></td>
         </tr>
       </tbody>
       <tfoot>
         <tr>
           <th rowspan="2" scope="col">Test</th>
-          <th colspan="2" scope="col">Yandex 1.7 + "Longdesc" extension (made
+	  <th colspan="2" scope="col">Yandex
+	    1.7 + "long&shy;desc" exten&shy;sion (made
             for Chrome),&nbsp; MacOS</th>
           <th colspan="2" scope="col">FF 23, MacOS 10.7.5</th>
           <th colspan="2" scope="col">FF 23, JAWS 15</th>
           <th colspan="2" scope="col">IE10, JAWS 15</th>
           <th colspan="2" scope="col">FF 27 Aviewer</th>
-          <th colspan="2" scope="col">NVDA2013.2, FF23</th>
-          <th colspan="2" scope="col">NVDA2013.2, IE10</th>
+          <th colspan="2" scope="col">NVDA 2013.2, FF23</th>
+          <th colspan="2" scope="col">NVDA 2013.2, IE10</th>
           <th colspan="2" scope="col">Opera 12.15, MacOS 10.7.5</th>
           <th colspan="2" scope="col">iCab 5.1, MacOS 10.7.5</th>
           <th colspan="2" scope="col">Orca, FF 32, Linux</th>
         </tr>
       </tfoot>
     </table>
+	<p>Notes</p>
+	<ul>
+	  <li><sup id="fna1">[1]</sup>
+	    Discovery is achieved by user-config&shy;urable
+            high&shy;lighting.</li>
+	  <li><sup id="fna2">[2]</sup> Access to the description is poor. You can get the URL of the longdesc, then copy it and paste it into a tab.</li>
+	  <li><sup id="fna3">[3]</sup> Discovery is weak - there is a longdesc option in the context menu when there is a longdesc available.</li>
+	  <li><sup id="fna4">[4]</sup> Data:uri images fail to render properly.
+	  (This is not a <code>longdesc</code> bug).</li>
+	  <li><sup id="fna5">[5]</sup>
+	    N/A: For tests where the image is empty, Gecko fails
+            to expose the presence of the longdesc via ATK or "to all users" and
+            hence Orca doesn't see it; this is a Gecko bug, not an Orca or
+            longdesc bug.<br>
+            <span title="fail">✕</span>: For tests where the description is found in a fragment, Orca
+            does not present the page starting with that fragment. It presents
+            the page starting from the top. Note, this is a Gecko bug, not an
+	    Orca bug.</td></li>
+	</ul>
     </section>
 
     <section id="mfresults-exposure">
     <h2 id="muftapi">Table 2: Multi-function tests - API exposure</h2>
-    <table style="width: 1091px; height: 818px;" border="1">
+    <div class="stretch">
+    <table border="1">
       <tbody>
         <tr>
           <th rowspan="2">Accessibility API / User Agent</th>
@@ -570,76 +598,78 @@
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-data-uri-description.html">ext
               img - data:URI desc</a></th>
-          <td class="pass">PASS <sup>[<a href="#fn1">1</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
-          <td class="pass">PASS <sup>[<a href="#fn7">7</a>]</sup></td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn1">1</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn7">7</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/empty-image-external-description.html">empty
               img - external desc</a></th>
-          <td class="pass">PASS <sup>[<a href="#fn2">2</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
-          <td class="fail">FAIL <sup>[<a href="#fn6">6</a>]</sup></td>
-          <td class="fail">FAIL <sup>[<a href="#fn8">8</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn2">2</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
+          <td class="fail"><span title="fail">✕</span> <sup>[<a href="#fn6">6</a>]</sup></td>
+          <td class="fail"><span title="fail">✕</span> <sup>[<a href="#fn8">8</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-external-description.html">ext
               img - ext desc</a></th>
-          <td class="pass">PASS <sup>[<a href="#fn2">2</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
-          <td class="pass">PASS <sup>[<a href="#fn7">7</a>]</sup></td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn2">2</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn7">7</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-internal-description.html">ext
               img - internal desc</a></th>
-          <td class="pass">FAIL <sup>[<a href="#fn3">3</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
-          <td class="pass">PASS <sup>[<a href="#fn7">7</a>]</sup></td>
-          <td class="pass">PASS</td>
+          <td class="fail"><span title="fail">✕</span> <sup>[<a href="#fn3">3</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn7">7</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-external-description-fragment-girt-by-spaces.html">ext
               img - ext desc fragment with spaces</a></th>
-          <td class="pass">PASS <sup>[<a href="#fn4">4</a>] [<a href="#fn6">6</a>]</sup></td>
-          <td class="pass">PASS <sup>[<a href="#fn7">7</a>]</sup></td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn4">4</a>] [<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn7">7</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-external-description-fragment.html">ext
               img - ext desc fragment</a></th>
-          <td class="pass">PASS <sup>[<a href="#fn4">4</a>] [<a href="#fn6">6</a>]</sup></td>
-          <td class="pass">PASS <sup>[<a href="#fn7">7</a>]</sup></td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn4">4</a>] [<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn7">7</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-with-absolute-base-external-description.html">ext
               img - ext desc with absolute base</a></th>
-          <td class="pass">PASS <sup>[<a href="#fn5">5</a>] [<a href="#fn6">6</a>]</sup></td>
-          <td class="pass">PASS <sup>[<a href="#fn7">7</a>]</sup></td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn5">5</a>] [<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn7">7</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/external-image-with-relative-base-external-description.html">ext
               img - ext desc with relative base</a></th>
-          <td class="pass">PASS <sup>[<a href="#fn5">5</a>] [<a href="#fn6">6</a>]</sup></td>
-          <td class="pass">PASS <sup>[<a href="#fn7">7</a>]</sup></td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn5">5</a>] [<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn7">7</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/iframe-discoverability.html">img
               in <code>&lt;iframe&gt;</code></a></th>
-          <td class="pass">PASS <sup>[<a href="#fn2">2</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
-          <td class="pass">PASS <sup>[<a href="#fn7">7</a>]</sup></td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn2">2</a>]</sup> <sup>[<a href="#fn6">6</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span> <sup>[<a href="#fn7">7</a>]</sup></td>
+          <td class="pass"><span title="pass">✔</span></td>
           <!--* Orca *-->
         </tr>
       </tbody>
     </table>
+  </div>
+  <p>Notes</p>
     <ul>
       <li><sup id="fn1">[1]</sup> accDescription has value of "data:text/html"</li>
       <li><sup id="fn2">[2]</sup> accDescription has value of "pass.html"</li>
@@ -647,9 +677,9 @@
       <li><sup id="fn4">[4]</sup> accDescription has value of
         "pass-fragment.html#fragment"</li>
       <li><sup id="fn5">[5]</sup> accDescription has value of "fail.html"</li>
-      <li><sup id="fn6">[6]</sup> FAIL: accDefaultAction: [null]</li>
-      <li><sup id="fn7">[7]</sup> PASS: accDefaultAction: showlongdesc</li>
-      <li><sup id="fn8">[8]</sup> FAIL: a bug prevents Gecko from making
+      <li><sup id="fn6">[6]</sup> <span title="fail">✕</span>: accDefaultAction: [null]</li>
+      <li><sup id="fn7">[7]</sup> <span title="pass">✔</span>: accDefaultAction: showlongdesc</li>
+      <li><sup id="fn8">[8]</sup> <span title="fail">✕</span>: a bug prevents Gecko from making
         longdesc available when there is no image; this is neither an Orca bug
         nor a longdesc bug. See Mozilla <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1056334">bug
           1056334</a>.</li>
@@ -663,22 +693,22 @@
       <tbody>
         <tr>
           <th scope="col">Test</th>
-          <th>Yandex browser 1.7 + "Longdesc" extension, MacOS</th>
+          <th>Yandex browser 1.7 + Long&shy;desc ext&shy;ension, MacOS</th>
           <th>FF 23 + JAWS 15, Win</th>
           <th>IE10 + JAWS 15, Win</th>
-          <th>FF23 + NVDA2013.2, Win</th>
-          <th>IE 10 + NVDA2013.2, Win</th>
+          <th>FF23 + NVDA 2013.2, Win</th>
+          <th>IE 10 + NVDA 2013.2, Win</th>
           <th>Opera 12.15, MacOS 10.7.5</th>
         </tr>
         <tr>
           <th scope="row"><a href="https://rawgithub.com/chaals/longdesc-tests/master/reflected-changing-longdesc.html">longdesc
               updated by javascript</a></th>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
-          <td class="pass">PASS</td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
+          <td class="pass"><span title="pass">✔</span></td>
         </tr>
       </tbody>
     </table>

--- a/html-longdesc/w3clogo-longdesc.txt
+++ b/html-longdesc/w3clogo-longdesc.txt
@@ -1,0 +1,17 @@
+W3C logo image.
+
+The logo of the World Wide Web Consortium (W3C)
+is made from the letter W and digit 3 in solid blue,
+the top bar of the digit touching the top of the W;
+these are followed by a white C with a solid black shadow
+to its right and slightly below it, all on a white background so
+that the C has no left side but touches the 3 closely enough that
+the contour of the 3 provides the left side ot the letter C.
+
+There are horizontal lines the width of the logo above and below.
+
+There is a very small R in a circle denoting a registered
+trade mark after the C of W3C.
+
+The logo uses a font called "Base 12 Sans Regular" from Emigre Fonts,
+designed by Zuzana Licko in 1995.


### PR DESCRIPTION
And hey, added a longdesc attribute so we'll have an example.
