### PR TITLE
Fix broken link

### DIFF
--- a/pointerevents/all.html
+++ b/pointerevents/all.html
@@ -13,7 +13,7 @@
       </header>
       <p><strong>Test files</strong>: 64; <strong>Total subtests</strong>: 644</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/pointerevents/pointereventconstructor.html</a></li>
+<ol class='toc'><li><a href='#test-file-0'>/pointerevents/pointerevent_constructor.html</a></li>
 <li><a href='#test-file-1'>/pointerevents/pointerevent_touch-action-illegal.html</a></li>
 <li><a href='#test-file-2'>/pointerevents/pointerevent_touch-action-verification.html</a></li>
 <li><a href='#test-file-3'>/pointerevents/pointerevent_button_attribute_mouse-manual.html</a></li>
@@ -80,7 +80,7 @@
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test</th><th>FF36</th><th>IE11</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/pointerevents/pointereventconstructor.html' target='_blank'>/pointerevents/pointereventconstructor.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/pointerevents/pointerevent_constructor.html' target='_blank'>/pointerevents/pointerevent_constructor.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>PointerEvent constructor</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>custom bubbles</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>custom cancelable</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>


### PR DESCRIPTION
Assuming this file is not generated dynamically, this would fix a typo in the url to the pointerevent-constructor test case.
