### PR TITLE
disallowing tfoot before tbody

### DIFF
--- a/html51/implementation-report.html
+++ b/html51/implementation-report.html
@@ -338,7 +338,7 @@ width="72"></a></p>
 <tr>
 <tr>
 <th><a href="https://github.com/whatwg/html/commit/94d55af9cda601ce675d15f6a0e52c9bb9c6afa9">Disallow <code>&lt;tfoot&gt;</code> before <code>&lt;tbody&gt;</code></a></th>
-<td colspan="5" class="notTested">?</td><td>W3C ref/issue?</td>
+<td colspan="5">No browser behaviour required</td><td>Not implemented in validator.w3.org</td>
 </tr>
 </table>
 


### PR DESCRIPTION
results - no browser behaviour required, but should file a bug on the
validator
