### PR TITLE
X origin track

### DIFF
--- a/html51/implementation-report.html
+++ b/html51/implementation-report.html
@@ -249,7 +249,7 @@ width="72"></a></p>
 <td class="pass">Yandex</td><td class="partial">*</td><td class="notTested">?</td><td class="notTested">?</td><td class="pass">Y</td><td>Firefox doesn't seem to <strong>show<strong> the captions, despite loading them.
 <p><a href="http://chaals.github.io/testcases/x-origin-track-element-very-manual.html">A <strong>very</strong> manual test…</a></p></td>
 </tr>
-<tr><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td><code>eventSource</code></td>
+<tr><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td><code>eventSource</code> should behave the same as above - the bugfix was in one piece of spec that covers both cases.</td>
 </tr>
 
 <tr>

--- a/html51/implementation-report.html
+++ b/html51/implementation-report.html
@@ -245,8 +245,11 @@ width="72"></a></p>
 </tr>
 
 <tr>
-<th><a href="https://github.com/whatwg/html/commit/c89cb55ba2a5571628d101bfd20ba0a1d076c990">Allow cross-origin <code>&lt;track&gt;</code> and <code>eventSource</code></a></th>
-<td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td>No W3C issue/reference?</td>
+<th rowspan="2"><a href="https://github.com/whatwg/html/commit/c89cb55ba2a5571628d101bfd20ba0a1d076c990">Allow cross-origin <code>&lt;track&gt;</code> and <code>eventSource</code></a></th>
+<td class="pass">Yandex</td><td class="partial">*</td><td class="notTested">?</td><td class="notTested">?</td><td class="pass">Y</td><td>Firefox doesn't seem to <strong>show<strong> the captions, despite loading them.
+<p><a href="http://chaals.github.io/testcases/x-origin-track-element-very-manual.html">A <strong>very</strong> manual test…</a></p></td>
+</tr>
+<tr><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td class="notTested">?</td><td><code>eventSource</code></td>
 </tr>
 
 <tr>


### PR DESCRIPTION
eventSource is untested, but should behave the same since it's the same
bit of spec that handles both cases - and the fix really was a bug fix.
