### PR TITLE
Update ambient-light test results

### DIFF
--- a/ambient-light/CA57.json
+++ b/ambient-light/CA57.json
@@ -34,8 +34,8 @@
       "subtests": [
         {
           "name": "event change fired",
-          "status": "FAIL",
-          "message": "assert_equals: expected \"activated\" bug got \"active\""
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -68,11 +68,11 @@
         },
         {
           "name": "Test that the sensor reading is updated when time passes.",
-          "status": "TIMEOUT",
-          "message": "Test timed out"
+          "status": "PASS",
+          "message": null
         }
       ],
-      "status": "TIMEOUT",
+      "status": "OK",
       "message": null
     },
     {
@@ -169,8 +169,8 @@
         },
         {
           "name": "Stringification of new AmbientLightSensor();",
-          "status": "FAIL",
-          "message": "Cannot read property \"has_stringifler\" of undefined"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"state\" with the proper type (0)",
@@ -194,18 +194,18 @@
         },
         {
           "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onchange\" with the proper type (4)",
-          "status": "FAIL",
-          "message": "Unrecognized type EventHandler"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onactivate\" with the proper type (5)",
-          "status": "FAIL",
-          "message": "Unrecognized type EventHandler"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onerror\" with the proper type (6)",
-          "status": "FAIL",
-          "message": "Unrecognized type EventHandler"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "AmbientLightSensorReading interface: existence and properties of interface object",

--- a/ambient-light/CA57.json
+++ b/ambient-light/CA57.json
@@ -1,0 +1,265 @@
+{
+  "results": [
+    {
+      "test": "/ambient-light/AmbientLightSensor_browsing_context.https.html",
+      "subtests": [
+        {
+          "name": "throw a 'SecurityError' when firing sensor readings within iframes",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "sensor readings can not be fired on the background tab",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_insecure_context.html",
+      "subtests": [
+        {
+          "name": "throw a 'SecurityError' when construct AmbientLightSensor in an insecure context",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_onchange.https.html",
+      "subtests": [
+        {
+          "name": "event change fired",
+          "status": "FAIL",
+          "message": "assert_equals: expected \"activated\" bug got \"active\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_onerror-manual.https.html",
+      "subtests": [
+        {
+          "name": "Test that 'onerror' event is fired when sensor is not supported",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_reading.https.html",
+      "subtests": [
+        {
+          "name": "Test that sensor reading must be immutable.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Test that sensor reading is correct.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Test that the sensor reading is updated when time passes.",
+          "status": "TIMEOUT",
+          "message": "Test timed out"
+        }
+      ],
+      "status": "TIMEOUT",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_start.https.html",
+      "subtests": [
+        {
+          "name": "The default sensor.reading is 'null'",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "The default sensor.state is 'idle'",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "The sensor.state changes to 'activating' after sensor.start()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "the sensor.start() return undefined",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "throw an InvalidStateError exception when state is neither idle nor errored",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_stop.https.html",
+      "subtests": [
+        {
+          "name": "The sensor.state changes to 'idle' after sensor.stop()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "the sensor.reading is null after executing stop() method",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "throw an InvalidStateError exception when state is either idle or errored",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "the sensor.stop() returns undefined",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/idlharness.https.html",
+      "subtests": [
+        {
+          "name": "AmbientLightSensor interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensor interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensor interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensor interface: existence and properties of interface prototype object",
+          "status": "FAIL",
+          "message": "assert_equals: class string of AmbientLightSensor.prototype expected \"[object AmbientLightSensorPrototype]\" but got \"[object AmbientLightSensor]\""
+        },
+        {
+          "name": "AmbientLightSensor interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensor must be primary interface of new AmbientLightSensor();",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of new AmbientLightSensor();",
+          "status": "FAIL",
+          "message": "Cannot read property \"has_stringifler\" of undefined"
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"state\" with the proper type (0)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"reading\" with the proper type (1)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"start\" with the proper type (2)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"stop\" with the proper type (3)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onchange\" with the proper type (4)",
+          "status": "FAIL",
+          "message": "Unrecognized type EventHandler"
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onactivate\" with the proper type (5)",
+          "status": "FAIL",
+          "message": "Unrecognized type EventHandler"
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onerror\" with the proper type (6)",
+          "status": "FAIL",
+          "message": "Unrecognized type EventHandler"
+        },
+        {
+          "name": "AmbientLightSensorReading interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface: existence and properties of interface prototype object",
+          "status": "FAIL",
+          "message": "assert_equals: class string of AmbientLightSensorReading.prototype expected \"[object AmbientLightSensorReadingPrototype]\" but got \"[object AmbientLightSensorReading]\""
+        },
+        {
+          "name": "AmbientLightSensorReading interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface: attribute illuminance",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading must be primary interface of new AmbientLightSensorReading({ illuminance: 750 });",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of new AmbientLightSensorReading({ illuminance: 750 });",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property \"illuminance\" with the proper type (0)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "SensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property \"timeStamp\" with the proper type (0)",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/ambient-light/CD57.json
+++ b/ambient-light/CD57.json
@@ -1,0 +1,265 @@
+{
+  "results": [
+    {
+      "test": "/ambient-light/AmbientLightSensor_browsing_context.https.html",
+      "subtests": [
+        {
+          "name": "throw a 'SecurityError' when firing sensor readings within iframes",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "sensor readings can not be fired on the background tab",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_insecure_context.html",
+      "subtests": [
+        {
+          "name": "throw a 'SecurityError' when construct AmbientLightSensor in an insecure context",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_onchange.https.html",
+      "subtests": [
+        {
+          "name": "event change fired",
+          "status": "TIMEOUT",
+          "message": null
+        }
+      ],
+      "status": "TIMEOUT",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_onerror-manual.https.html",
+      "subtests": [
+        {
+          "name": "Test that 'onerror' event is fired when sensor is not supported",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_reading.https.html",
+      "subtests": [
+        {
+          "name": "Test that sensor reading must be immutable.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Test that sensor reading is correct.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Test that the sensor reading is updated when time passes.",
+          "status": "TIMEOUT",
+          "message": "Test timed out"
+        }
+      ],
+      "status": "TIMEOUT",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_start.https.html",
+      "subtests": [
+        {
+          "name": "The default sensor.reading is 'null'",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "The default sensor.state is 'idle'",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "The sensor.state changes to 'activating' after sensor.start()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "the sensor.start() return undefined",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "throw an InvalidStateError exception when state is neither idle nor errored",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/AmbientLightSensor_stop.https.html",
+      "subtests": [
+        {
+          "name": "The sensor.state changes to 'idle' after sensor.stop()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "the sensor.reading is null after executing stop() method",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "throw an InvalidStateError exception when state is either idle or errored",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "the sensor.stop() returns undefined",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/ambient-light/idlharness.https.html",
+      "subtests": [
+        {
+          "name": "AmbientLightSensor interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensor interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensor interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensor interface: existence and properties of interface prototype object",
+          "status": "FAIL",
+          "message": "assert_equals: class string of AmbientLightSensor.prototype expected \"[object AmbientLightSensorPrototype]\" but got \"[object AmbientLightSensor]\""
+        },
+        {
+          "name": "AmbientLightSensor interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensor must be primary interface of new AmbientLightSensor();",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of new AmbientLightSensor();",
+          "status": "FAIL",
+          "message": "Cannot read property \"has_stringifler\" of undefined"
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"state\" with the proper type (0)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"reading\" with the proper type (1)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"start\" with the proper type (2)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"stop\" with the proper type (3)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onchange\" with the proper type (4)",
+          "status": "FAIL",
+          "message": "Unrecognized type EventHandler"
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onactivate\" with the proper type (5)",
+          "status": "FAIL",
+          "message": "Unrecognized type EventHandler"
+        },
+        {
+          "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onerror\" with the proper type (6)",
+          "status": "FAIL",
+          "message": "Unrecognized type EventHandler"
+        },
+        {
+          "name": "AmbientLightSensorReading interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface: existence and properties of interface prototype object",
+          "status": "FAIL",
+          "message": "assert_equals: class string of AmbientLightSensorReading.prototype expected \"[object AmbientLightSensorReadingPrototype]\" but got \"[object AmbientLightSensorReading]\""
+        },
+        {
+          "name": "AmbientLightSensorReading interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface: attribute illuminance",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading must be primary interface of new AmbientLightSensorReading({ illuminance: 750 });",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of new AmbientLightSensorReading({ illuminance: 750 });",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "AmbientLightSensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property \"illuminance\" with the proper type (0)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "SensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property \"timeStamp\" with the proper type (0)",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/ambient-light/CD57.json
+++ b/ambient-light/CD57.json
@@ -34,11 +34,11 @@
       "subtests": [
         {
           "name": "event change fired",
-          "status": "TIMEOUT",
+          "status": "PASS",
           "message": null
         }
       ],
-      "status": "TIMEOUT",
+      "status": "OK",
       "message": null
     },
     {
@@ -68,11 +68,11 @@
         },
         {
           "name": "Test that the sensor reading is updated when time passes.",
-          "status": "TIMEOUT",
-          "message": "Test timed out"
+          "status": "PASS",
+          "message": null
         }
       ],
-      "status": "TIMEOUT",
+      "status": "OK",
       "message": null
     },
     {
@@ -169,8 +169,8 @@
         },
         {
           "name": "Stringification of new AmbientLightSensor();",
-          "status": "FAIL",
-          "message": "Cannot read property \"has_stringifler\" of undefined"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"state\" with the proper type (0)",
@@ -194,18 +194,18 @@
         },
         {
           "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onchange\" with the proper type (4)",
-          "status": "FAIL",
-          "message": "Unrecognized type EventHandler"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onactivate\" with the proper type (5)",
-          "status": "FAIL",
-          "message": "Unrecognized type EventHandler"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "Sensor interface: new AmbientLightSensor(); must inherit property \"onerror\" with the proper type (6)",
-          "status": "FAIL",
-          "message": "Unrecognized type EventHandler"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "AmbientLightSensorReading interface: existence and properties of interface object",

--- a/ambient-light/all.html
+++ b/ambient-light/all.html
@@ -30,13 +30,13 @@
 <tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_insecure_context.html' target='_blank'>/ambient-light/AmbientLightSensor_insecure_context.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>throw a 'SecurityError' when construct AmbientLightSensor in an insecure context</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_onchange.https.html' target='_blank'>/ambient-light/AmbientLightSensor_onchange.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>event change fired</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr class='subtest'><td>event change fired</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_onerror-manual.https.html' target='_blank'>/ambient-light/AmbientLightSensor_onerror-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>Test that 'onerror' event is fired when sensor is not supported</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_reading.https.html' target='_blank'>/ambient-light/AmbientLightSensor_reading.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>Test that sensor reading must be immutable.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Test that sensor reading is correct.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Test that the sensor reading is updated when time passes.</td><td class='TIMEOUT'>TIMEOUT</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr class='subtest'><td>Test that the sensor reading is updated when time passes.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_start.https.html' target='_blank'>/ambient-light/AmbientLightSensor_start.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>The default sensor.reading is 'null'</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>The default sensor.state is 'idle'</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
@@ -55,14 +55,14 @@
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensor must be primary interface of new AmbientLightSensor();</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Stringification of new AmbientLightSensor();</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>Stringification of new AmbientLightSensor();</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "state" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "reading" with the proper type (1)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "start" with the proper type (2)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "stop" with the proper type (3)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onchange" with the proper type (4)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onactivate" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onerror" with the proper type (6)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onchange" with the proper type (4)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onactivate" with the proper type (5)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onerror" with the proper type (6)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>

--- a/ambient-light/all.html
+++ b/ambient-light/all.html
@@ -2,44 +2,69 @@
 <html lang='en'>
   <head>
     <meta charset='utf-8'>
-    <title>Ambient Light Sensor: All Results</title>
+    <title>ambient-light: All Results</title>
     <link rel='stylesheet' href='bootstrap.min.css'>
     <link rel='stylesheet' href='analysis.css'>
   </head>
   <body>
     <div class='container'>
       <header>
-        <h1>Ambient Light Sensor: All Results</h1>
+        <h1>ambient-light: All Results</h1>
       </header>
-      <p><strong>Test files</strong>: 2; <strong>Total subtests</strong>: 30</p>
+      <p><strong>Test files</strong>: 8; <strong>Total subtests</strong>: 41</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/ambient-light/idlharness.html</a></li>
-<li><a href='#test-file-1'>/ambient-light/AmbientLightSensor_tests.html</a></li>
+<ol class='toc'><li><a href='#test-file-0'>/ambient-light/AmbientLightSensor_browsing_context.https.html</a></li>
+<li><a href='#test-file-1'>/ambient-light/AmbientLightSensor_insecure_context.html</a></li>
+<li><a href='#test-file-2'>/ambient-light/AmbientLightSensor_onchange.https.html</a></li>
+<li><a href='#test-file-3'>/ambient-light/AmbientLightSensor_onerror-manual.https.html</a></li>
+<li><a href='#test-file-4'>/ambient-light/AmbientLightSensor_reading.https.html</a></li>
+<li><a href='#test-file-5'>/ambient-light/AmbientLightSensor_start.https.html</a></li>
+<li><a href='#test-file-6'>/ambient-light/AmbientLightSensor_stop.https.html</a></li>
+<li><a href='#test-file-7'>/ambient-light/idlharness.https.html</a></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>Chromium 52</th><th>Chromium 52</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.html' target='_blank'>/ambient-light/idlharness.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>SensorReadingEvent must be primary interface of new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) });</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Stringification of new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) });</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>SensorReadingEvent interface: new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) }); must inherit property "reading" with the proper type (0)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+        <thead><tr class='persist-header'><th>Test</th><th>CA57</th><th>CD57</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_browsing_context.https.html' target='_blank'>/ambient-light/AmbientLightSensor_browsing_context.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>throw a 'SecurityError' when firing sensor readings within iframes</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>sensor readings can not be fired on the background tab</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_insecure_context.html' target='_blank'>/ambient-light/AmbientLightSensor_insecure_context.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>throw a 'SecurityError' when construct AmbientLightSensor in an insecure context</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_onchange.https.html' target='_blank'>/ambient-light/AmbientLightSensor_onchange.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>event change fired</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_onerror-manual.https.html' target='_blank'>/ambient-light/AmbientLightSensor_onerror-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>Test that 'onerror' event is fired when sensor is not supported</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_reading.https.html' target='_blank'>/ambient-light/AmbientLightSensor_reading.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>Test that sensor reading must be immutable.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>Test that sensor reading is correct.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>Test that the sensor reading is updated when time passes.</td><td class='TIMEOUT'>TIMEOUT</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_start.https.html' target='_blank'>/ambient-light/AmbientLightSensor_start.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>The default sensor.reading is 'null'</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>The default sensor.state is 'idle'</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>The sensor.state changes to 'activating' after sensor.start()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>the sensor.start() return undefined</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>throw an InvalidStateError exception when state is neither idle nor errored</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_stop.https.html' target='_blank'>/ambient-light/AmbientLightSensor_stop.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>The sensor.state changes to 'idle' after sensor.stop()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>the sensor.reading is null after executing stop() method</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>throw an InvalidStateError exception when state is either idle or errored</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>the sensor.stop() returns undefined</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.https.html' target='_blank'>/ambient-light/idlharness.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>AmbientLightSensor interface: attribute reading</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensor must be primary interface of new AmbientLightSensor();</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Stringification of new AmbientLightSensor();</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>AmbientLightSensor interface: new AmbientLightSensor(); must inherit property "reading" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "state" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "reading" with the proper type (1)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "start" with the proper type (2)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "stop" with the proper type (3)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onchange" with the proper type (4)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onstatechange" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onactivate" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onerror" with the proper type (6)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>AmbientLightSensorReading interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>AmbientLightSensorReading interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
@@ -48,8 +73,6 @@
 <tr class='subtest'><td>Stringification of new AmbientLightSensorReading({ illuminance: 750 });</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property "illuminance" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='subtest'><td>SensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property "timeStamp" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_tests.html' target='_blank'>/ambient-light/AmbientLightSensor_tests.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Test suite not implemented yet.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>
     </div>

--- a/ambient-light/complete-fails.html
+++ b/ambient-light/complete-fails.html
@@ -2,35 +2,34 @@
 <html lang='en'>
   <head>
     <meta charset='utf-8'>
-    <title>Ambient Light Sensor: Complete Failures</title>
+    <title>ambient-light: Complete Failures</title>
     <link rel='stylesheet' href='bootstrap.min.css'>
     <link rel='stylesheet' href='analysis.css'>
   </head>
   <body>
     <div class='container'>
       <header>
-        <h1>Ambient Light Sensor: Complete Failures</h1>
+        <h1>ambient-light: Complete Failures</h1>
       </header>
-      <p><strong>Completely failed files</strong>: 2; <strong>Completely failed subtests</strong>: 11; <strong>Failure level</strong>: 11/30 (36.67%)</p>
+      <p><strong>Completely failed files</strong>: 3; <strong>Completely failed subtests</strong>: 8; <strong>Failure level</strong>: 8/41 (19.51%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/ambient-light/idlharness.html</a> <small>(10/29, 34.48%, 33.33% of total)</small></li>
-<li><a href='#test-file-1'>/ambient-light/AmbientLightSensor_tests.html</a> <small>(1/1, 100.00%, 3.33% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/ambient-light/AmbientLightSensor_onchange.https.html</a> <small>(1/1, 100.00%, 2.44% of total)</small></li>
+<li><a href='#test-file-1'>/ambient-light/AmbientLightSensor_reading.https.html</a> <small>(1/3, 33.33%, 2.44% of total)</small></li>
+<li><a href='#test-file-2'>/ambient-light/idlharness.https.html</a> <small>(6/24, 25.00%, 14.63% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>CA52</th><th>CH52</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.html' target='_blank'>/ambient-light/idlharness.html</a> <small>(10/29, 34.48%, 33.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>SensorReadingEvent must be primary interface of new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) });</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Stringification of new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) });</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>SensorReadingEvent interface: new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) }); must inherit property "reading" with the proper type (0)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+        <thead><tr class='persist-header'><th>Test</th><th>CA57</th><th>CD57</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_onchange.https.html' target='_blank'>/ambient-light/AmbientLightSensor_onchange.https.html</a> <small>(1/1, 100.00%, 2.44% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>event change fired</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_reading.https.html' target='_blank'>/ambient-light/AmbientLightSensor_reading.https.html</a> <small>(1/3, 33.33%, 2.44% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>Test that the sensor reading is updated when time passes.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.https.html' target='_blank'>/ambient-light/idlharness.https.html</a> <small>(6/24, 25.00%, 14.63% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>Stringification of new AmbientLightSensor();</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onchange" with the proper type (4)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onstatechange" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onactivate" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onerror" with the proper type (6)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>AmbientLightSensorReading interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_tests.html' target='_blank'>/ambient-light/AmbientLightSensor_tests.html</a> <small>(1/1, 100.00%, 3.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Test suite not implemented yet.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>
     </div>

--- a/ambient-light/complete-fails.html
+++ b/ambient-light/complete-fails.html
@@ -11,24 +11,14 @@
       <header>
         <h1>ambient-light: Complete Failures</h1>
       </header>
-      <p><strong>Completely failed files</strong>: 3; <strong>Completely failed subtests</strong>: 8; <strong>Failure level</strong>: 8/41 (19.51%)</p>
+      <p><strong>Completely failed files</strong>: 1; <strong>Completely failed subtests</strong>: 2; <strong>Failure level</strong>: 2/41 (4.88%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/ambient-light/AmbientLightSensor_onchange.https.html</a> <small>(1/1, 100.00%, 2.44% of total)</small></li>
-<li><a href='#test-file-1'>/ambient-light/AmbientLightSensor_reading.https.html</a> <small>(1/3, 33.33%, 2.44% of total)</small></li>
-<li><a href='#test-file-2'>/ambient-light/idlharness.https.html</a> <small>(6/24, 25.00%, 14.63% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/ambient-light/idlharness.https.html</a> <small>(2/24, 8.33%, 4.88% of total)</small></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test</th><th>CA57</th><th>CD57</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_onchange.https.html' target='_blank'>/ambient-light/AmbientLightSensor_onchange.https.html</a> <small>(1/1, 100.00%, 2.44% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>event change fired</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_reading.https.html' target='_blank'>/ambient-light/AmbientLightSensor_reading.https.html</a> <small>(1/3, 33.33%, 2.44% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Test that the sensor reading is updated when time passes.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.https.html' target='_blank'>/ambient-light/idlharness.https.html</a> <small>(6/24, 25.00%, 14.63% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.https.html' target='_blank'>/ambient-light/idlharness.https.html</a> <small>(2/24, 8.33%, 4.88% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Stringification of new AmbientLightSensor();</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onchange" with the proper type (4)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onactivate" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onerror" with the proper type (6)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>

--- a/ambient-light/consolidated.json
+++ b/ambient-light/consolidated.json
@@ -64,11 +64,11 @@
       "subtests": {
         "event change fired": {
           "byUA": {
-            "CA57": "FAIL",
-            "CD57": "FAIL"
+            "CA57": "PASS",
+            "CD57": "PASS"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 2
           }
         }
       }
@@ -122,11 +122,11 @@
         },
         "Test that the sensor reading is updated when time passes.": {
           "byUA": {
-            "CA57": "FAIL",
-            "CD57": "FAIL"
+            "CA57": "PASS",
+            "CD57": "PASS"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 2
           }
         }
       }
@@ -299,11 +299,11 @@
         },
         "Stringification of new AmbientLightSensor();": {
           "byUA": {
-            "CA57": "FAIL",
-            "CD57": "FAIL"
+            "CA57": "PASS",
+            "CD57": "PASS"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 2
           }
         },
         "Sensor interface: new AmbientLightSensor(); must inherit property \"state\" with the proper type (0)": {
@@ -344,29 +344,29 @@
         },
         "Sensor interface: new AmbientLightSensor(); must inherit property \"onchange\" with the proper type (4)": {
           "byUA": {
-            "CA57": "FAIL",
-            "CD57": "FAIL"
+            "CA57": "PASS",
+            "CD57": "PASS"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 2
           }
         },
         "Sensor interface: new AmbientLightSensor(); must inherit property \"onactivate\" with the proper type (5)": {
           "byUA": {
-            "CA57": "FAIL",
-            "CD57": "FAIL"
+            "CA57": "PASS",
+            "CD57": "PASS"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 2
           }
         },
         "Sensor interface: new AmbientLightSensor(); must inherit property \"onerror\" with the proper type (6)": {
           "byUA": {
-            "CA57": "FAIL",
-            "CD57": "FAIL"
+            "CA57": "PASS",
+            "CD57": "PASS"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 2
           }
         },
         "AmbientLightSensorReading interface: existence and properties of interface object": {

--- a/ambient-light/consolidated.json
+++ b/ambient-light/consolidated.json
@@ -1,274 +1,31 @@
 {
   "ua": [
-    "CA52",
-    "CH52"
+    "CA57",
+    "CD57"
   ],
   "results": {
-    "/ambient-light/idlharness.html": {
+    "/ambient-light/AmbientLightSensor_browsing_context.https.html": {
       "byUA": {
-        "CA52": "OK",
-        "CH52": "OK"
+        "CA57": "OK",
+        "CD57": "OK"
       },
       "totals": {
         "OK": 2
       },
       "subtests": {
-        "SensorReadingEvent must be primary interface of new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) });": {
+        "throw a 'SecurityError' when firing sensor readings within iframes": {
           "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "Stringification of new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) });": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "SensorReadingEvent interface: new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) }); must inherit property \"reading\" with the proper type (0)": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "AmbientLightSensor interface: existence and properties of interface object": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
+            "CA57": "PASS",
+            "CD57": "PASS"
           },
           "totals": {
             "PASS": 2
           }
         },
-        "AmbientLightSensor interface object length": {
+        "sensor readings can not be fired on the background tab": {
           "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensor interface object name": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensor interface: existence and properties of interface prototype object": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "AmbientLightSensor interface: existence and properties of interface prototype object's \"constructor\" property": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensor interface: attribute reading": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensor must be primary interface of new AmbientLightSensor();": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "Stringification of new AmbientLightSensor();": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "AmbientLightSensor interface: new AmbientLightSensor(); must inherit property \"reading\" with the proper type (0)": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "Sensor interface: new AmbientLightSensor(); must inherit property \"state\" with the proper type (0)": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "Sensor interface: new AmbientLightSensor(); must inherit property \"reading\" with the proper type (1)": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "Sensor interface: new AmbientLightSensor(); must inherit property \"start\" with the proper type (2)": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "Sensor interface: new AmbientLightSensor(); must inherit property \"stop\" with the proper type (3)": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "Sensor interface: new AmbientLightSensor(); must inherit property \"onchange\" with the proper type (4)": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "Sensor interface: new AmbientLightSensor(); must inherit property \"onstatechange\" with the proper type (5)": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "Sensor interface: new AmbientLightSensor(); must inherit property \"onerror\" with the proper type (6)": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "AmbientLightSensorReading interface: existence and properties of interface object": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensorReading interface object length": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "AmbientLightSensorReading interface object name": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensorReading interface: existence and properties of interface prototype object": {
-          "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
-          },
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "AmbientLightSensorReading interface: existence and properties of interface prototype object's \"constructor\" property": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensorReading interface: attribute illuminance": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensorReading must be primary interface of new AmbientLightSensorReading({ illuminance: 750 });": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "Stringification of new AmbientLightSensorReading({ illuminance: 750 });": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "AmbientLightSensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property \"illuminance\" with the proper type (0)": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
-          },
-          "totals": {
-            "PASS": 2
-          }
-        },
-        "SensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property \"timeStamp\" with the proper type (0)": {
-          "byUA": {
-            "CA52": "PASS",
-            "CH52": "PASS"
+            "CA57": "PASS",
+            "CD57": "PASS"
           },
           "totals": {
             "PASS": 2
@@ -276,22 +33,430 @@
         }
       }
     },
-    "/ambient-light/AmbientLightSensor_tests.html": {
+    "/ambient-light/AmbientLightSensor_insecure_context.html": {
       "byUA": {
-        "CA52": "OK",
-        "CH52": "OK"
+        "CA57": "OK",
+        "CD57": "OK"
       },
       "totals": {
         "OK": 2
       },
       "subtests": {
-        "Test suite not implemented yet.": {
+        "throw a 'SecurityError' when construct AmbientLightSensor in an insecure context": {
           "byUA": {
-            "CA52": "FAIL",
-            "CH52": "FAIL"
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        }
+      }
+    },
+    "/ambient-light/AmbientLightSensor_onchange.https.html": {
+      "byUA": {
+        "CA57": "OK",
+        "CD57": "OK"
+      },
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "event change fired": {
+          "byUA": {
+            "CA57": "FAIL",
+            "CD57": "FAIL"
           },
           "totals": {
             "FAIL": 2
+          }
+        }
+      }
+    },
+    "/ambient-light/AmbientLightSensor_onerror-manual.https.html": {
+      "byUA": {
+        "CA57": "OK",
+        "CD57": "OK"
+      },
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "Test that 'onerror' event is fired when sensor is not supported": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        }
+      }
+    },
+    "/ambient-light/AmbientLightSensor_reading.https.html": {
+      "byUA": {
+        "CA57": "OK",
+        "CD57": "OK"
+      },
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "Test that sensor reading must be immutable.": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "Test that sensor reading is correct.": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "Test that the sensor reading is updated when time passes.": {
+          "byUA": {
+            "CA57": "FAIL",
+            "CD57": "FAIL"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        }
+      }
+    },
+    "/ambient-light/AmbientLightSensor_start.https.html": {
+      "byUA": {
+        "CA57": "OK",
+        "CD57": "OK"
+      },
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "The default sensor.reading is 'null'": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "The default sensor.state is 'idle'": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "The sensor.state changes to 'activating' after sensor.start()": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "the sensor.start() return undefined": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "throw an InvalidStateError exception when state is neither idle nor errored": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        }
+      }
+    },
+    "/ambient-light/AmbientLightSensor_stop.https.html": {
+      "byUA": {
+        "CA57": "OK",
+        "CD57": "OK"
+      },
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "The sensor.state changes to 'idle' after sensor.stop()": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "the sensor.reading is null after executing stop() method": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "throw an InvalidStateError exception when state is either idle or errored": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "the sensor.stop() returns undefined": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        }
+      }
+    },
+    "/ambient-light/idlharness.https.html": {
+      "byUA": {
+        "CA57": "OK",
+        "CD57": "OK"
+      },
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "AmbientLightSensor interface: existence and properties of interface object": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensor interface object length": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensor interface object name": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensor interface: existence and properties of interface prototype object": {
+          "byUA": {
+            "CA57": "FAIL",
+            "CD57": "FAIL"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        },
+        "AmbientLightSensor interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensor must be primary interface of new AmbientLightSensor();": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "Stringification of new AmbientLightSensor();": {
+          "byUA": {
+            "CA57": "FAIL",
+            "CD57": "FAIL"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        },
+        "Sensor interface: new AmbientLightSensor(); must inherit property \"state\" with the proper type (0)": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "Sensor interface: new AmbientLightSensor(); must inherit property \"reading\" with the proper type (1)": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "Sensor interface: new AmbientLightSensor(); must inherit property \"start\" with the proper type (2)": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "Sensor interface: new AmbientLightSensor(); must inherit property \"stop\" with the proper type (3)": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "Sensor interface: new AmbientLightSensor(); must inherit property \"onchange\" with the proper type (4)": {
+          "byUA": {
+            "CA57": "FAIL",
+            "CD57": "FAIL"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        },
+        "Sensor interface: new AmbientLightSensor(); must inherit property \"onactivate\" with the proper type (5)": {
+          "byUA": {
+            "CA57": "FAIL",
+            "CD57": "FAIL"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        },
+        "Sensor interface: new AmbientLightSensor(); must inherit property \"onerror\" with the proper type (6)": {
+          "byUA": {
+            "CA57": "FAIL",
+            "CD57": "FAIL"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        },
+        "AmbientLightSensorReading interface: existence and properties of interface object": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensorReading interface object length": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensorReading interface object name": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensorReading interface: existence and properties of interface prototype object": {
+          "byUA": {
+            "CA57": "FAIL",
+            "CD57": "FAIL"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        },
+        "AmbientLightSensorReading interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensorReading interface: attribute illuminance": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensorReading must be primary interface of new AmbientLightSensorReading({ illuminance: 750 });": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "Stringification of new AmbientLightSensorReading({ illuminance: 750 });": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "AmbientLightSensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property \"illuminance\" with the proper type (0)": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "SensorReading interface: new AmbientLightSensorReading({ illuminance: 750 }); must inherit property \"timeStamp\" with the proper type (0)": {
+          "byUA": {
+            "CA57": "PASS",
+            "CD57": "PASS"
+          },
+          "totals": {
+            "PASS": 2
           }
         }
       }

--- a/ambient-light/less-than-2.html
+++ b/ambient-light/less-than-2.html
@@ -2,35 +2,34 @@
 <html lang='en'>
   <head>
     <meta charset='utf-8'>
-    <title>Ambient Light Sensor: Less Than 2 Passes</title>
+    <title>ambient-light: Less Than 2 Passes</title>
     <link rel='stylesheet' href='bootstrap.min.css'>
     <link rel='stylesheet' href='analysis.css'>
   </head>
   <body>
     <div class='container'>
       <header>
-        <h1>Ambient Light Sensor: Less Than 2 Passes</h1>
+        <h1>ambient-light: Less Than 2 Passes</h1>
       </header>
-      <p><strong>Test files without 2 passes</strong>: 2; <strong>Subtests without 2 passes: </strong>11; <strong>Failure level</strong>: 11/30 (36.67%)</p>
+      <p><strong>Test files without 2 passes</strong>: 3; <strong>Subtests without 2 passes: </strong>8; <strong>Failure level</strong>: 8/41 (19.51%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/ambient-light/idlharness.html</a> <small>(10/29, 34.48%, 33.33% of total)</small></li>
-<li><a href='#test-file-1'>/ambient-light/AmbientLightSensor_tests.html</a> <small>(1/1, 100.00%, 3.33% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/ambient-light/AmbientLightSensor_onchange.https.html</a> <small>(1/1, 100.00%, 2.44% of total)</small></li>
+<li><a href='#test-file-1'>/ambient-light/AmbientLightSensor_reading.https.html</a> <small>(1/3, 33.33%, 2.44% of total)</small></li>
+<li><a href='#test-file-2'>/ambient-light/idlharness.https.html</a> <small>(6/24, 25.00%, 14.63% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>CA52</th><th>CH52</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.html' target='_blank'>/ambient-light/idlharness.html</a> <small>(10/29, 34.48%, 33.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>SensorReadingEvent must be primary interface of new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) });</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Stringification of new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) });</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>SensorReadingEvent interface: new SensorReadingEvent({ reading: new AmbientLightSensorReading({ illuminance: 750 }) }); must inherit property "reading" with the proper type (0)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+        <thead><tr class='persist-header'><th>Test</th><th>CA57</th><th>CD57</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_onchange.https.html' target='_blank'>/ambient-light/AmbientLightSensor_onchange.https.html</a> <small>(1/1, 100.00%, 2.44% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>event change fired</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_reading.https.html' target='_blank'>/ambient-light/AmbientLightSensor_reading.https.html</a> <small>(1/3, 33.33%, 2.44% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>Test that the sensor reading is updated when time passes.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.https.html' target='_blank'>/ambient-light/idlharness.https.html</a> <small>(6/24, 25.00%, 14.63% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>Stringification of new AmbientLightSensor();</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onchange" with the proper type (4)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onstatechange" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onactivate" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onerror" with the proper type (6)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>AmbientLightSensorReading interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_tests.html' target='_blank'>/ambient-light/AmbientLightSensor_tests.html</a> <small>(1/1, 100.00%, 3.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Test suite not implemented yet.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>
     </div>

--- a/ambient-light/less-than-2.html
+++ b/ambient-light/less-than-2.html
@@ -11,24 +11,14 @@
       <header>
         <h1>ambient-light: Less Than 2 Passes</h1>
       </header>
-      <p><strong>Test files without 2 passes</strong>: 3; <strong>Subtests without 2 passes: </strong>8; <strong>Failure level</strong>: 8/41 (19.51%)</p>
+      <p><strong>Test files without 2 passes</strong>: 1; <strong>Subtests without 2 passes: </strong>2; <strong>Failure level</strong>: 2/41 (4.88%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/ambient-light/AmbientLightSensor_onchange.https.html</a> <small>(1/1, 100.00%, 2.44% of total)</small></li>
-<li><a href='#test-file-1'>/ambient-light/AmbientLightSensor_reading.https.html</a> <small>(1/3, 33.33%, 2.44% of total)</small></li>
-<li><a href='#test-file-2'>/ambient-light/idlharness.https.html</a> <small>(6/24, 25.00%, 14.63% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/ambient-light/idlharness.https.html</a> <small>(2/24, 8.33%, 4.88% of total)</small></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test</th><th>CA57</th><th>CD57</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_onchange.https.html' target='_blank'>/ambient-light/AmbientLightSensor_onchange.https.html</a> <small>(1/1, 100.00%, 2.44% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>event change fired</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/ambient-light/AmbientLightSensor_reading.https.html' target='_blank'>/ambient-light/AmbientLightSensor_reading.https.html</a> <small>(1/3, 33.33%, 2.44% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Test that the sensor reading is updated when time passes.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.https.html' target='_blank'>/ambient-light/idlharness.https.html</a> <small>(6/24, 25.00%, 14.63% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/ambient-light/idlharness.https.html' target='_blank'>/ambient-light/idlharness.https.html</a> <small>(2/24, 8.33%, 4.88% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr class='subtest'><td>AmbientLightSensor interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Stringification of new AmbientLightSensor();</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onchange" with the proper type (4)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onactivate" with the proper type (5)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Sensor interface: new AmbientLightSensor(); must inherit property "onerror" with the proper type (6)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='subtest'><td>AmbientLightSensorReading interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>


### PR DESCRIPTION
 - Chrome Canary 57 for Android
 - Chrome Canary 57 for Windows
 - Enable the API by navigating to: chrome://flags/#enable-generic-sensor