### PR TITLE
Initial placeholders for results

### DIFF
--- a/dpub-aam/README.md
+++ b/dpub-aam/README.md
@@ -1,0 +1,14 @@
+Digital Publishing Accessibility API Mappings test results
+==========================================================
+
+This document is a place holder until test results are available.
+
+Up-to-date result reports are available at:
+
+* https://w3c.github.io/test-results/dpub-aam/all.html
+* https://w3c.github.io/test-results/dpub-aam/less-than-2.html
+* https://w3c.github.io/test-results/dpub-aam/complete-fails.html
+
+Index of implementations in reports
+===================================
+

--- a/dpub-aria/README.md
+++ b/dpub-aria/README.md
@@ -1,0 +1,14 @@
+Digital Publishing WAI-ARIA Module test results
+===============================================
+
+This document is a place holder until test results are available.
+
+Up-to-date result reports are available at:
+
+* https://w3c.github.io/test-results/dpub-aria/all.html
+* https://w3c.github.io/test-results/dpub-aria/less-than-2.html
+* https://w3c.github.io/test-results/dpub-aria/complete-fails.html
+
+Index of implementations in reports
+===================================
+


### PR DESCRIPTION
These specs are entering CR and need a location where the results WILL BE.  This corresponds to the shortnames and directories in WPT.