### PR TITLE
Fix typo in report-header.html

### DIFF
--- a/annotation-model/all.html
+++ b/annotation-model/all.html
@@ -104,7 +104,7 @@
             <tr>
                 <td><strong>External web resources, used as the Target of an Annotation.</strong></td>
                 <td>Must pass all of:<ul>
-                    <li><a href="#subtest-1-41">annotationOptionals, subtest 1:51</a> Implements <strong>External Web Resource</strong> with <strong><em>id</em> key</strong> as a target of the Annotation</li>
+                    <li><a href="#subtest-1-40">annotationOptionals, subtest 1:51</a> Implements <strong>External Web Resource</strong> with <strong><em>id</em> key</strong> as a target of the Annotation</li>
                     <li><a href="#subtest-0-34">annotationMusts, subtest 1:36</a> If an <strong>External Web Resource</strong> is a target, it does NOT have an <strong><em>items</em> key</strong></li>
                     <li><a href="#subtest-0-35">annotationMusts, subtest 1:37</a> If an <strong>External Web Resource</strong> is a target, it does NOT have an <strong><em>purpose</em> key</strong></li></ul></td>
                 <td><strong>DG, EB, HY, KM, MM, RN, TK</strong></td>

--- a/annotation-model/report-header.html
+++ b/annotation-model/report-header.html
@@ -91,7 +91,7 @@
             <tr>
                 <td><strong>External web resources, used as the Target of an Annotation.</strong></td>
                 <td>Must pass all of:<ul>
-                    <li><a href="#subtest-1-41">annotationOptionals, subtest 1:51</a> Implements <strong>External Web Resource</strong> with <strong><em>id</em> key</strong> as a target of the Annotation</li>
+                    <li><a href="#subtest-1-40">annotationOptionals, subtest 1:51</a> Implements <strong>External Web Resource</strong> with <strong><em>id</em> key</strong> as a target of the Annotation</li>
                     <li><a href="#subtest-0-34">annotationMusts, subtest 1:36</a> If an <strong>External Web Resource</strong> is a target, it does NOT have an <strong><em>items</em> key</strong></li>
                     <li><a href="#subtest-0-35">annotationMusts, subtest 1:37</a> If an <strong>External Web Resource</strong> is a target, it does NOT have an <strong><em>purpose</em> key</strong></li></ul></td>
                 <td><strong>DG, EB, HY, KM, MM, RN, TK</strong></td>


### PR DESCRIPTION
In previous edit, I typed subtest-1-41 in an href rather than subtest-1-40, so that internal link is dead until this PR is merged. 