### PR TITLE
wai-aria: Updated results for aria-rowspan and aria-colspan tests

### DIFF
--- a/wai-aria/FF01.json
+++ b/wai-aria/FF01.json
@@ -446,6 +446,18 @@
       "message": null
     },
     {
+      "test": "/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html",
+      "subtests": [
+        {
+          "name": "cell aria-colspan 2 on td html colspan 3 with three actual columns",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
       "test": "/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html",
       "subtests": [
         {
@@ -475,7 +487,19 @@
         {
           "name": "cell aria-rowspan 2 on td html rowspan 3",
           "status": "FAIL",
-          "message": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:cell', 'table-cell-index:0', 'tag:td', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n; \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:cell', 'table-cell-index:0', 'tag:td', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html",
+      "subtests": [
+        {
+          "name": "cell aria-rowspan 2 on td html rowspan 3 with three actual rows",
+          "status": "FAIL",
+          "message": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=1, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -578,6 +602,18 @@
       "message": null
     },
     {
+      "test": "/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html",
+      "subtests": [
+        {
+          "name": "columnheader aria-colspan 2 on th html colspan 3 with three actual columns",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
       "test": "/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html",
       "subtests": [
         {
@@ -607,7 +643,19 @@
         {
           "name": "columnheader aria-rowspan 2 on th html rowspan 3",
           "status": "FAIL",
-          "message": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:center', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n; \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:center', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html",
+      "subtests": [
+        {
+          "name": "columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows",
+          "status": "FAIL",
+          "message": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=1, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false"
         }
       ],
       "status": "OK",

--- a/wai-aria/GC02.json
+++ b/wai-aria/GC02.json
@@ -446,6 +446,18 @@
       "message": null
     },
     {
+      "test": "/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html",
+      "subtests": [
+        {
+          "name": "cell aria-colspan 2 on td html colspan 3 with three actual columns",
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
       "test": "/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html",
       "subtests": [
         {
@@ -474,6 +486,18 @@
       "subtests": [
         {
           "name": "cell aria-rowspan 2 on td html rowspan 3",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html",
+      "subtests": [
+        {
+          "name": "cell aria-rowspan 2 on td html rowspan 3 with three actual rows",
           "status": "FAIL",
           "message": "assert_true: \"property AXRowIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
@@ -570,6 +594,18 @@
       "subtests": [
         {
           "name": "columnheader aria-colspan 2 on th html colspan 3",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html",
+      "subtests": [
+        {
+          "name": "columnheader aria-colspan 2 on th html colspan 3 with three actual columns",
           "status": "FAIL",
           "message": "assert_true: \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
@@ -606,6 +642,18 @@
       "subtests": [
         {
           "name": "columnheader aria-rowspan 2 on th html rowspan 3",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html",
+      "subtests": [
+        {
+          "name": "columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows",
           "status": "FAIL",
           "message": "assert_true: \"property AXRowIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
         }

--- a/wai-aria/WK01.json
+++ b/wai-aria/WK01.json
@@ -426,8 +426,8 @@
       "subtests": [
         {
           "name": "cell aria-colspan 2 on td html colspan 3",
-          "status": "FAIL",
-          "message": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=3\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://webkit.org/b/171165>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should return values of aria-rowspan and aria-colspan, if present  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -438,6 +438,18 @@
       "subtests": [
         {
           "name": "cell aria-colspan 2 on td html colspan 3 with headers and border",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html",
+      "subtests": [
+        {
+          "name": "cell aria-colspan 2 on td html colspan 3 with three actual columns",
           "status": "PASS",
           "message": null
         }
@@ -474,6 +486,18 @@
       "subtests": [
         {
           "name": "cell aria-rowspan 2 on td html rowspan 3",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html",
+      "subtests": [
+        {
+          "name": "cell aria-rowspan 2 on td html rowspan 3 with three actual rows",
           "status": "PASS",
           "message": null
         }
@@ -570,8 +594,20 @@
       "subtests": [
         {
           "name": "columnheader aria-colspan 2 on th html colspan 3",
-          "status": "FAIL",
-          "message": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=3\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://webkit.org/b/171165>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should return values of aria-rowspan and aria-colspan, if present  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html",
+      "subtests": [
+        {
+          "name": "columnheader aria-colspan 2 on th html colspan 3 with three actual columns",
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -606,6 +642,18 @@
       "subtests": [
         {
           "name": "columnheader aria-rowspan 2 on th html rowspan 3",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html",
+      "subtests": [
+        {
+          "name": "columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows",
           "status": "PASS",
           "message": null
         }

--- a/wai-aria/WK02.json
+++ b/wai-aria/WK02.json
@@ -426,8 +426,8 @@
       "subtests": [
         {
           "name": "cell aria-colspan 2 on td html colspan 3",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171178>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -438,6 +438,18 @@
       "subtests": [
         {
           "name": "cell aria-colspan 2 on td html colspan 3 with headers and border",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html",
+      "subtests": [
+        {
+          "name": "cell aria-colspan 2 on td html colspan 3 with three actual columns",
           "status": "PASS",
           "message": null
         }
@@ -474,6 +486,18 @@
       "subtests": [
         {
           "name": "cell aria-rowspan 2 on td html rowspan 3",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html",
+      "subtests": [
+        {
+          "name": "cell aria-rowspan 2 on td html rowspan 3 with three actual rows",
           "status": "PASS",
           "message": null
         }
@@ -570,8 +594,20 @@
       "subtests": [
         {
           "name": "columnheader aria-colspan 2 on th html colspan 3",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171178>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html",
+      "subtests": [
+        {
+          "name": "columnheader aria-colspan 2 on th html colspan 3 with three actual columns",
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -606,6 +642,18 @@
       "subtests": [
         {
           "name": "columnheader aria-rowspan 2 on th html rowspan 3",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html",
+      "subtests": [
+        {
+          "name": "columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows",
           "status": "PASS",
           "message": null
         }

--- a/wai-aria/all.html
+++ b/wai-aria/all.html
@@ -12,7 +12,7 @@
         <h1>WAI ARIA 1.1: All Results</h1>
       </header>
       
-      <p><strong>Test files</strong>: 223; <strong>Total subtests</strong>: 248</p>
+      <p><strong>Test files</strong>: 227; <strong>Total subtests</strong>: 252</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/wai-aria/alertdialog_modal_false-manual.html</a></li>
 <li><a href='#test-file-1'>/wai-aria/alertdialog_modal_true-manual.html</a></li>
@@ -49,194 +49,198 @@
 <li><a href='#test-file-32'>/wai-aria/cell_aria-colspan_2_on_div-manual.html</a></li>
 <li><a href='#test-file-33'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html</a></li>
 <li><a href='#test-file-34'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html</a></li>
-<li><a href='#test-file-35'>/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html</a></li>
-<li><a href='#test-file-36'>/wai-aria/cell_aria-rowspan_2_on_div-manual.html</a></li>
-<li><a href='#test-file-37'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html</a></li>
-<li><a href='#test-file-38'>/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html</a></li>
-<li><a href='#test-file-39'>/wai-aria/cell_colindex_4-manual.html</a></li>
-<li><a href='#test-file-40'>/wai-aria/cell_rowindex_4-manual.html</a></li>
-<li><a href='#test-file-41'>/wai-aria/checkbox_readonly_false-manual.html</a></li>
-<li><a href='#test-file-42'>/wai-aria/checkbox_readonly_true-manual.html</a></li>
-<li><a href='#test-file-43'>/wai-aria/checkbox_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-44'>/wai-aria/columnheader_aria-colspan_2_on_div-manual.html</a></li>
-<li><a href='#test-file-45'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a></li>
-<li><a href='#test-file-46'>/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html</a></li>
-<li><a href='#test-file-47'>/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html</a></li>
-<li><a href='#test-file-48'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html</a></li>
-<li><a href='#test-file-49'>/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html</a></li>
-<li><a href='#test-file-50'>/wai-aria/columnheader_colindex_4-manual.html</a></li>
-<li><a href='#test-file-51'>/wai-aria/columnheader_rowindex_4-manual.html</a></li>
-<li><a href='#test-file-52'>/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html</a></li>
-<li><a href='#test-file-53'>/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html</a></li>
-<li><a href='#test-file-54'>/wai-aria/combobox_controls_an_invalid_id-manual.html</a></li>
-<li><a href='#test-file-55'>/wai-aria/combobox_haspopup_dialog-manual.html</a></li>
-<li><a href='#test-file-56'>/wai-aria/combobox_haspopup_false-manual.html</a></li>
-<li><a href='#test-file-57'>/wai-aria/combobox_haspopup_grid-manual.html</a></li>
-<li><a href='#test-file-58'>/wai-aria/combobox_haspopup_listbox-manual.html</a></li>
-<li><a href='#test-file-59'>/wai-aria/combobox_haspopup_menu-manual.html</a></li>
-<li><a href='#test-file-60'>/wai-aria/combobox_haspopup_tree-manual.html</a></li>
-<li><a href='#test-file-61'>/wai-aria/combobox_haspopup_true-manual.html</a></li>
-<li><a href='#test-file-62'>/wai-aria/combobox_haspopup_unspecified-manual.html</a></li>
-<li><a href='#test-file-63'>/wai-aria/combobox_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-64'>/wai-aria/combobox_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-65'>/wai-aria/combobox_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-66'>/wai-aria/combobox_readonly_false-manual.html</a></li>
-<li><a href='#test-file-67'>/wai-aria/combobox_readonly_true-manual.html</a></li>
-<li><a href='#test-file-68'>/wai-aria/combobox_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-69'>/wai-aria/dialog_modal_false-manual.html</a></li>
-<li><a href='#test-file-70'>/wai-aria/dialog_modal_true-manual.html</a></li>
-<li><a href='#test-file-71'>/wai-aria/dialog_modal_unspecified-manual.html</a></li>
-<li><a href='#test-file-72'>/wai-aria/div_element_without_role_roledescription_valid-manual.html</a></li>
-<li><a href='#test-file-73'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a></li>
-<li><a href='#test-file-74'>/wai-aria/errormessage_object_in_valid_state-manual.html</a></li>
-<li><a href='#test-file-75'>/wai-aria/feed-manual.html</a></li>
-<li><a href='#test-file-76'>/wai-aria/figure-manual.html</a></li>
-<li><a href='#test-file-77'>/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html</a></li>
-<li><a href='#test-file-78'>/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html</a></li>
-<li><a href='#test-file-79'>/wai-aria/grid_busy_false-manual.html</a></li>
-<li><a href='#test-file-80'>/wai-aria/grid_busy_true-manual.html</a></li>
-<li><a href='#test-file-81'>/wai-aria/grid_busy_value_changes-manual.html</a></li>
-<li><a href='#test-file-82'>/wai-aria/grid_colcount_8-manual.html</a></li>
-<li><a href='#test-file-83'>/wai-aria/grid_columnheader_readonly_false-manual.html</a></li>
-<li><a href='#test-file-84'>/wai-aria/grid_columnheader_readonly_true-manual.html</a></li>
-<li><a href='#test-file-85'>/wai-aria/grid_columnheader_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-86'>/wai-aria/grid_columnheader_required_false-manual.html</a></li>
-<li><a href='#test-file-87'>/wai-aria/grid_columnheader_required_true-manual.html</a></li>
-<li><a href='#test-file-88'>/wai-aria/grid_columnheader_required_unspecified-manual.html</a></li>
-<li><a href='#test-file-89'>/wai-aria/grid_rowcount_3-manual.html</a></li>
-<li><a href='#test-file-90'>/wai-aria/grid_rowheader_readonly_false-manual.html</a></li>
-<li><a href='#test-file-91'>/wai-aria/grid_rowheader_readonly_true-manual.html</a></li>
-<li><a href='#test-file-92'>/wai-aria/grid_rowheader_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-93'>/wai-aria/grid_rowheader_required_false-manual.html</a></li>
-<li><a href='#test-file-94'>/wai-aria/grid_rowheader_required_true-manual.html</a></li>
-<li><a href='#test-file-95'>/wai-aria/grid_rowheader_required_unspecified-manual.html</a></li>
-<li><a href='#test-file-96'>/wai-aria/gridcell_aria-colspan_2_on_div-manual.html</a></li>
-<li><a href='#test-file-97'>/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html</a></li>
-<li><a href='#test-file-98'>/wai-aria/gridcell_colindex_4-manual.html</a></li>
-<li><a href='#test-file-99'>/wai-aria/gridcell_rowindex_4-manual.html</a></li>
-<li><a href='#test-file-100'>/wai-aria/group_hidden_undefined_element_not_rendered-manual.html</a></li>
-<li><a href='#test-file-101'>/wai-aria/group_hidden_undefined_element_rendered-manual.html</a></li>
-<li><a href='#test-file-102'>/wai-aria/heading_level_unspecified-manual.html</a></li>
-<li><a href='#test-file-103'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a></li>
-<li><a href='#test-file-104'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a></li>
-<li><a href='#test-file-105'>/wai-aria/listbox_busy_false-manual.html</a></li>
-<li><a href='#test-file-106'>/wai-aria/listbox_busy_true-manual.html</a></li>
-<li><a href='#test-file-107'>/wai-aria/listbox_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-108'>/wai-aria/listbox_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-109'>/wai-aria/listbox_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-110'>/wai-aria/listbox_readonly_false-manual.html</a></li>
-<li><a href='#test-file-111'>/wai-aria/listbox_readonly_true-manual.html</a></li>
-<li><a href='#test-file-112'>/wai-aria/listbox_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-113'>/wai-aria/listitem_setsize_-1-manual.html</a></li>
-<li><a href='#test-file-114'>/wai-aria/menu_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-115'>/wai-aria/menu_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-116'>/wai-aria/menu_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-117'>/wai-aria/menubar_busy_false-manual.html</a></li>
-<li><a href='#test-file-118'>/wai-aria/menubar_busy_true-manual.html</a></li>
-<li><a href='#test-file-119'>/wai-aria/menubar_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-120'>/wai-aria/menubar_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-121'>/wai-aria/menubar_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-122'>/wai-aria/menuitem_posinset_and_setsize-manual.html</a></li>
-<li><a href='#test-file-123'>/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html</a></li>
-<li><a href='#test-file-124'>/wai-aria/menuitemcheckbox_readonly_false-manual.html</a></li>
-<li><a href='#test-file-125'>/wai-aria/menuitemcheckbox_readonly_true-manual.html</a></li>
-<li><a href='#test-file-126'>/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-127'>/wai-aria/menuitemradio_posinset_and_setsize-manual.html</a></li>
-<li><a href='#test-file-128'>/wai-aria/menuitemradio_readonly_false-manual.html</a></li>
-<li><a href='#test-file-129'>/wai-aria/menuitemradio_readonly_true-manual.html</a></li>
-<li><a href='#test-file-130'>/wai-aria/menuitemradio_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-131'>/wai-aria/none-manual.html</a></li>
-<li><a href='#test-file-132'>/wai-aria/option_selected_false-manual.html</a></li>
-<li><a href='#test-file-133'>/wai-aria/option_selected_true-manual.html</a></li>
-<li><a href='#test-file-134'>/wai-aria/option_selected_undefined-manual.html</a></li>
-<li><a href='#test-file-135'>/wai-aria/option_selected_value_changes-manual.html</a></li>
-<li><a href='#test-file-136'>/wai-aria/radiogroup_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-137'>/wai-aria/radiogroup_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-138'>/wai-aria/radiogroup_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-139'>/wai-aria/radiogroup_readonly_false-manual.html</a></li>
-<li><a href='#test-file-140'>/wai-aria/radiogroup_readonly_true-manual.html</a></li>
-<li><a href='#test-file-141'>/wai-aria/radiogroup_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-142'>/wai-aria/region_with_name-manual.html</a></li>
-<li><a href='#test-file-143'>/wai-aria/region_without_name-manual.html</a></li>
-<li><a href='#test-file-144'>/wai-aria/row_colindex_4-manual.html</a></li>
-<li><a href='#test-file-145'>/wai-aria/row_rowindex_4-manual.html</a></li>
-<li><a href='#test-file-146'>/wai-aria/rowheader_aria-colspan_2_on_div-manual.html</a></li>
-<li><a href='#test-file-147'>/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html</a></li>
-<li><a href='#test-file-148'>/wai-aria/rowheader_colindex_4-manual.html</a></li>
-<li><a href='#test-file-149'>/wai-aria/rowheader_rowindex_4-manual.html</a></li>
-<li><a href='#test-file-150'>/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html</a></li>
-<li><a href='#test-file-151'>/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html</a></li>
-<li><a href='#test-file-152'>/wai-aria/scrollbar_all_values_unspecified-manual.html</a></li>
-<li><a href='#test-file-153'>/wai-aria/scrollbar_only_valuenow_unspecified-manual.html</a></li>
-<li><a href='#test-file-154'>/wai-aria/scrollbar_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-155'>/wai-aria/searchbox-manual.html</a></li>
-<li><a href='#test-file-156'>/wai-aria/searchbox_activedescendant-manual.html</a></li>
-<li><a href='#test-file-157'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a></li>
-<li><a href='#test-file-158'>/wai-aria/searchbox_autocomplete_both-manual.html</a></li>
-<li><a href='#test-file-159'>/wai-aria/searchbox_autocomplete_inline-manual.html</a></li>
-<li><a href='#test-file-160'>/wai-aria/searchbox_autocomplete_list-manual.html</a></li>
-<li><a href='#test-file-161'>/wai-aria/searchbox_autocomplete_none-manual.html</a></li>
-<li><a href='#test-file-162'>/wai-aria/searchbox_autocomplete_unspecified-manual.html</a></li>
-<li><a href='#test-file-163'>/wai-aria/searchbox_multiline_false-manual.html</a></li>
-<li><a href='#test-file-164'>/wai-aria/searchbox_multiline_true-manual.html</a></li>
-<li><a href='#test-file-165'>/wai-aria/searchbox_multiline_unspecified-manual.html</a></li>
-<li><a href='#test-file-166'>/wai-aria/searchbox_placeholder-manual.html</a></li>
-<li><a href='#test-file-167'>/wai-aria/searchbox_readonly_false-manual.html</a></li>
-<li><a href='#test-file-168'>/wai-aria/searchbox_readonly_true-manual.html</a></li>
-<li><a href='#test-file-169'>/wai-aria/searchbox_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-170'>/wai-aria/searchbox_required_false-manual.html</a></li>
-<li><a href='#test-file-171'>/wai-aria/searchbox_required_true-manual.html</a></li>
-<li><a href='#test-file-172'>/wai-aria/searchbox_required_unspecified-manual.html</a></li>
-<li><a href='#test-file-173'>/wai-aria/separator_focusable_all_values_unspecified-manual.html</a></li>
-<li><a href='#test-file-174'>/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html</a></li>
-<li><a href='#test-file-175'>/wai-aria/separator_focusable_valuetext-manual.html</a></li>
-<li><a href='#test-file-176'>/wai-aria/separator_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-177'>/wai-aria/separator_unfocusable_all_values_unspecified-manual.html</a></li>
-<li><a href='#test-file-178'>/wai-aria/separator_unfocusable_valuetext-manual.html</a></li>
-<li><a href='#test-file-179'>/wai-aria/slider_all_values_unspecified-manual.html</a></li>
-<li><a href='#test-file-180'>/wai-aria/slider_only_valuenow_unspecified-manual.html</a></li>
-<li><a href='#test-file-181'>/wai-aria/slider_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-182'>/wai-aria/slider_readonly_false-manual.html</a></li>
-<li><a href='#test-file-183'>/wai-aria/slider_readonly_true-manual.html</a></li>
-<li><a href='#test-file-184'>/wai-aria/slider_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-185'>/wai-aria/spinbutton_all_values_unspecified-manual.html</a></li>
-<li><a href='#test-file-186'>/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html</a></li>
-<li><a href='#test-file-187'>/wai-aria/spinbutton_readonly_false-manual.html</a></li>
-<li><a href='#test-file-188'>/wai-aria/spinbutton_readonly_true-manual.html</a></li>
-<li><a href='#test-file-189'>/wai-aria/spinbutton_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-190'>/wai-aria/switch_checked_false-manual.html</a></li>
-<li><a href='#test-file-191'>/wai-aria/switch_checked_mixed-manual.html</a></li>
-<li><a href='#test-file-192'>/wai-aria/switch_checked_true-manual.html</a></li>
-<li><a href='#test-file-193'>/wai-aria/switch_checked_undefined-manual.html</a></li>
-<li><a href='#test-file-194'>/wai-aria/switch_checked_value_changes-manual.html</a></li>
-<li><a href='#test-file-195'>/wai-aria/switch_readonly_false-manual.html</a></li>
-<li><a href='#test-file-196'>/wai-aria/switch_readonly_true-manual.html</a></li>
-<li><a href='#test-file-197'>/wai-aria/switch_readonly_unspecified-manual.html</a></li>
-<li><a href='#test-file-198'>/wai-aria/tab_posinset_and_setsize-manual.html</a></li>
-<li><a href='#test-file-199'>/wai-aria/table_colcount_-1-manual.html</a></li>
-<li><a href='#test-file-200'>/wai-aria/table_colcount_8-manual.html</a></li>
-<li><a href='#test-file-201'>/wai-aria/table_rowcount_-1-manual.html</a></li>
-<li><a href='#test-file-202'>/wai-aria/table_rowcount_3-manual.html</a></li>
-<li><a href='#test-file-203'>/wai-aria/tablist_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-204'>/wai-aria/tablist_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-205'>/wai-aria/tablist_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-206'>/wai-aria/term_role-manual.html</a></li>
-<li><a href='#test-file-207'>/wai-aria/textbox_placeholder-manual.html</a></li>
-<li><a href='#test-file-208'>/wai-aria/toolbar_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-209'>/wai-aria/toolbar_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-210'>/wai-aria/toolbar_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-211'>/wai-aria/tree_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-212'>/wai-aria/tree_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-213'>/wai-aria/tree_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-214'>/wai-aria/treegrid_colcount_8-manual.html</a></li>
-<li><a href='#test-file-215'>/wai-aria/treegrid_orientation_horizontal-manual.html</a></li>
-<li><a href='#test-file-216'>/wai-aria/treegrid_orientation_unspecified-manual.html</a></li>
-<li><a href='#test-file-217'>/wai-aria/treegrid_orientation_vertical-manual.html</a></li>
-<li><a href='#test-file-218'>/wai-aria/treegrid_rowcount_3-manual.html</a></li>
-<li><a href='#test-file-219'>/wai-aria/treeitem_selected_false-manual.html</a></li>
-<li><a href='#test-file-220'>/wai-aria/treeitem_selected_true-manual.html</a></li>
-<li><a href='#test-file-221'>/wai-aria/treeitem_selected_undefined-manual.html</a></li>
-<li><a href='#test-file-222'>/wai-aria/treeitem_selected_value_changes-manual.html</a></li>
+<li><a href='#test-file-35'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html</a></li>
+<li><a href='#test-file-36'>/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html</a></li>
+<li><a href='#test-file-37'>/wai-aria/cell_aria-rowspan_2_on_div-manual.html</a></li>
+<li><a href='#test-file-38'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html</a></li>
+<li><a href='#test-file-39'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html</a></li>
+<li><a href='#test-file-40'>/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html</a></li>
+<li><a href='#test-file-41'>/wai-aria/cell_colindex_4-manual.html</a></li>
+<li><a href='#test-file-42'>/wai-aria/cell_rowindex_4-manual.html</a></li>
+<li><a href='#test-file-43'>/wai-aria/checkbox_readonly_false-manual.html</a></li>
+<li><a href='#test-file-44'>/wai-aria/checkbox_readonly_true-manual.html</a></li>
+<li><a href='#test-file-45'>/wai-aria/checkbox_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-46'>/wai-aria/columnheader_aria-colspan_2_on_div-manual.html</a></li>
+<li><a href='#test-file-47'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a></li>
+<li><a href='#test-file-48'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html</a></li>
+<li><a href='#test-file-49'>/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html</a></li>
+<li><a href='#test-file-50'>/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html</a></li>
+<li><a href='#test-file-51'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html</a></li>
+<li><a href='#test-file-52'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html</a></li>
+<li><a href='#test-file-53'>/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html</a></li>
+<li><a href='#test-file-54'>/wai-aria/columnheader_colindex_4-manual.html</a></li>
+<li><a href='#test-file-55'>/wai-aria/columnheader_rowindex_4-manual.html</a></li>
+<li><a href='#test-file-56'>/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html</a></li>
+<li><a href='#test-file-57'>/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html</a></li>
+<li><a href='#test-file-58'>/wai-aria/combobox_controls_an_invalid_id-manual.html</a></li>
+<li><a href='#test-file-59'>/wai-aria/combobox_haspopup_dialog-manual.html</a></li>
+<li><a href='#test-file-60'>/wai-aria/combobox_haspopup_false-manual.html</a></li>
+<li><a href='#test-file-61'>/wai-aria/combobox_haspopup_grid-manual.html</a></li>
+<li><a href='#test-file-62'>/wai-aria/combobox_haspopup_listbox-manual.html</a></li>
+<li><a href='#test-file-63'>/wai-aria/combobox_haspopup_menu-manual.html</a></li>
+<li><a href='#test-file-64'>/wai-aria/combobox_haspopup_tree-manual.html</a></li>
+<li><a href='#test-file-65'>/wai-aria/combobox_haspopup_true-manual.html</a></li>
+<li><a href='#test-file-66'>/wai-aria/combobox_haspopup_unspecified-manual.html</a></li>
+<li><a href='#test-file-67'>/wai-aria/combobox_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-68'>/wai-aria/combobox_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-69'>/wai-aria/combobox_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-70'>/wai-aria/combobox_readonly_false-manual.html</a></li>
+<li><a href='#test-file-71'>/wai-aria/combobox_readonly_true-manual.html</a></li>
+<li><a href='#test-file-72'>/wai-aria/combobox_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-73'>/wai-aria/dialog_modal_false-manual.html</a></li>
+<li><a href='#test-file-74'>/wai-aria/dialog_modal_true-manual.html</a></li>
+<li><a href='#test-file-75'>/wai-aria/dialog_modal_unspecified-manual.html</a></li>
+<li><a href='#test-file-76'>/wai-aria/div_element_without_role_roledescription_valid-manual.html</a></li>
+<li><a href='#test-file-77'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a></li>
+<li><a href='#test-file-78'>/wai-aria/errormessage_object_in_valid_state-manual.html</a></li>
+<li><a href='#test-file-79'>/wai-aria/feed-manual.html</a></li>
+<li><a href='#test-file-80'>/wai-aria/figure-manual.html</a></li>
+<li><a href='#test-file-81'>/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html</a></li>
+<li><a href='#test-file-82'>/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html</a></li>
+<li><a href='#test-file-83'>/wai-aria/grid_busy_false-manual.html</a></li>
+<li><a href='#test-file-84'>/wai-aria/grid_busy_true-manual.html</a></li>
+<li><a href='#test-file-85'>/wai-aria/grid_busy_value_changes-manual.html</a></li>
+<li><a href='#test-file-86'>/wai-aria/grid_colcount_8-manual.html</a></li>
+<li><a href='#test-file-87'>/wai-aria/grid_columnheader_readonly_false-manual.html</a></li>
+<li><a href='#test-file-88'>/wai-aria/grid_columnheader_readonly_true-manual.html</a></li>
+<li><a href='#test-file-89'>/wai-aria/grid_columnheader_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-90'>/wai-aria/grid_columnheader_required_false-manual.html</a></li>
+<li><a href='#test-file-91'>/wai-aria/grid_columnheader_required_true-manual.html</a></li>
+<li><a href='#test-file-92'>/wai-aria/grid_columnheader_required_unspecified-manual.html</a></li>
+<li><a href='#test-file-93'>/wai-aria/grid_rowcount_3-manual.html</a></li>
+<li><a href='#test-file-94'>/wai-aria/grid_rowheader_readonly_false-manual.html</a></li>
+<li><a href='#test-file-95'>/wai-aria/grid_rowheader_readonly_true-manual.html</a></li>
+<li><a href='#test-file-96'>/wai-aria/grid_rowheader_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-97'>/wai-aria/grid_rowheader_required_false-manual.html</a></li>
+<li><a href='#test-file-98'>/wai-aria/grid_rowheader_required_true-manual.html</a></li>
+<li><a href='#test-file-99'>/wai-aria/grid_rowheader_required_unspecified-manual.html</a></li>
+<li><a href='#test-file-100'>/wai-aria/gridcell_aria-colspan_2_on_div-manual.html</a></li>
+<li><a href='#test-file-101'>/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html</a></li>
+<li><a href='#test-file-102'>/wai-aria/gridcell_colindex_4-manual.html</a></li>
+<li><a href='#test-file-103'>/wai-aria/gridcell_rowindex_4-manual.html</a></li>
+<li><a href='#test-file-104'>/wai-aria/group_hidden_undefined_element_not_rendered-manual.html</a></li>
+<li><a href='#test-file-105'>/wai-aria/group_hidden_undefined_element_rendered-manual.html</a></li>
+<li><a href='#test-file-106'>/wai-aria/heading_level_unspecified-manual.html</a></li>
+<li><a href='#test-file-107'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a></li>
+<li><a href='#test-file-108'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a></li>
+<li><a href='#test-file-109'>/wai-aria/listbox_busy_false-manual.html</a></li>
+<li><a href='#test-file-110'>/wai-aria/listbox_busy_true-manual.html</a></li>
+<li><a href='#test-file-111'>/wai-aria/listbox_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-112'>/wai-aria/listbox_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-113'>/wai-aria/listbox_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-114'>/wai-aria/listbox_readonly_false-manual.html</a></li>
+<li><a href='#test-file-115'>/wai-aria/listbox_readonly_true-manual.html</a></li>
+<li><a href='#test-file-116'>/wai-aria/listbox_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-117'>/wai-aria/listitem_setsize_-1-manual.html</a></li>
+<li><a href='#test-file-118'>/wai-aria/menu_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-119'>/wai-aria/menu_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-120'>/wai-aria/menu_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-121'>/wai-aria/menubar_busy_false-manual.html</a></li>
+<li><a href='#test-file-122'>/wai-aria/menubar_busy_true-manual.html</a></li>
+<li><a href='#test-file-123'>/wai-aria/menubar_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-124'>/wai-aria/menubar_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-125'>/wai-aria/menubar_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-126'>/wai-aria/menuitem_posinset_and_setsize-manual.html</a></li>
+<li><a href='#test-file-127'>/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html</a></li>
+<li><a href='#test-file-128'>/wai-aria/menuitemcheckbox_readonly_false-manual.html</a></li>
+<li><a href='#test-file-129'>/wai-aria/menuitemcheckbox_readonly_true-manual.html</a></li>
+<li><a href='#test-file-130'>/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-131'>/wai-aria/menuitemradio_posinset_and_setsize-manual.html</a></li>
+<li><a href='#test-file-132'>/wai-aria/menuitemradio_readonly_false-manual.html</a></li>
+<li><a href='#test-file-133'>/wai-aria/menuitemradio_readonly_true-manual.html</a></li>
+<li><a href='#test-file-134'>/wai-aria/menuitemradio_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-135'>/wai-aria/none-manual.html</a></li>
+<li><a href='#test-file-136'>/wai-aria/option_selected_false-manual.html</a></li>
+<li><a href='#test-file-137'>/wai-aria/option_selected_true-manual.html</a></li>
+<li><a href='#test-file-138'>/wai-aria/option_selected_undefined-manual.html</a></li>
+<li><a href='#test-file-139'>/wai-aria/option_selected_value_changes-manual.html</a></li>
+<li><a href='#test-file-140'>/wai-aria/radiogroup_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-141'>/wai-aria/radiogroup_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-142'>/wai-aria/radiogroup_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-143'>/wai-aria/radiogroup_readonly_false-manual.html</a></li>
+<li><a href='#test-file-144'>/wai-aria/radiogroup_readonly_true-manual.html</a></li>
+<li><a href='#test-file-145'>/wai-aria/radiogroup_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-146'>/wai-aria/region_with_name-manual.html</a></li>
+<li><a href='#test-file-147'>/wai-aria/region_without_name-manual.html</a></li>
+<li><a href='#test-file-148'>/wai-aria/row_colindex_4-manual.html</a></li>
+<li><a href='#test-file-149'>/wai-aria/row_rowindex_4-manual.html</a></li>
+<li><a href='#test-file-150'>/wai-aria/rowheader_aria-colspan_2_on_div-manual.html</a></li>
+<li><a href='#test-file-151'>/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html</a></li>
+<li><a href='#test-file-152'>/wai-aria/rowheader_colindex_4-manual.html</a></li>
+<li><a href='#test-file-153'>/wai-aria/rowheader_rowindex_4-manual.html</a></li>
+<li><a href='#test-file-154'>/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html</a></li>
+<li><a href='#test-file-155'>/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html</a></li>
+<li><a href='#test-file-156'>/wai-aria/scrollbar_all_values_unspecified-manual.html</a></li>
+<li><a href='#test-file-157'>/wai-aria/scrollbar_only_valuenow_unspecified-manual.html</a></li>
+<li><a href='#test-file-158'>/wai-aria/scrollbar_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-159'>/wai-aria/searchbox-manual.html</a></li>
+<li><a href='#test-file-160'>/wai-aria/searchbox_activedescendant-manual.html</a></li>
+<li><a href='#test-file-161'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a></li>
+<li><a href='#test-file-162'>/wai-aria/searchbox_autocomplete_both-manual.html</a></li>
+<li><a href='#test-file-163'>/wai-aria/searchbox_autocomplete_inline-manual.html</a></li>
+<li><a href='#test-file-164'>/wai-aria/searchbox_autocomplete_list-manual.html</a></li>
+<li><a href='#test-file-165'>/wai-aria/searchbox_autocomplete_none-manual.html</a></li>
+<li><a href='#test-file-166'>/wai-aria/searchbox_autocomplete_unspecified-manual.html</a></li>
+<li><a href='#test-file-167'>/wai-aria/searchbox_multiline_false-manual.html</a></li>
+<li><a href='#test-file-168'>/wai-aria/searchbox_multiline_true-manual.html</a></li>
+<li><a href='#test-file-169'>/wai-aria/searchbox_multiline_unspecified-manual.html</a></li>
+<li><a href='#test-file-170'>/wai-aria/searchbox_placeholder-manual.html</a></li>
+<li><a href='#test-file-171'>/wai-aria/searchbox_readonly_false-manual.html</a></li>
+<li><a href='#test-file-172'>/wai-aria/searchbox_readonly_true-manual.html</a></li>
+<li><a href='#test-file-173'>/wai-aria/searchbox_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-174'>/wai-aria/searchbox_required_false-manual.html</a></li>
+<li><a href='#test-file-175'>/wai-aria/searchbox_required_true-manual.html</a></li>
+<li><a href='#test-file-176'>/wai-aria/searchbox_required_unspecified-manual.html</a></li>
+<li><a href='#test-file-177'>/wai-aria/separator_focusable_all_values_unspecified-manual.html</a></li>
+<li><a href='#test-file-178'>/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html</a></li>
+<li><a href='#test-file-179'>/wai-aria/separator_focusable_valuetext-manual.html</a></li>
+<li><a href='#test-file-180'>/wai-aria/separator_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-181'>/wai-aria/separator_unfocusable_all_values_unspecified-manual.html</a></li>
+<li><a href='#test-file-182'>/wai-aria/separator_unfocusable_valuetext-manual.html</a></li>
+<li><a href='#test-file-183'>/wai-aria/slider_all_values_unspecified-manual.html</a></li>
+<li><a href='#test-file-184'>/wai-aria/slider_only_valuenow_unspecified-manual.html</a></li>
+<li><a href='#test-file-185'>/wai-aria/slider_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-186'>/wai-aria/slider_readonly_false-manual.html</a></li>
+<li><a href='#test-file-187'>/wai-aria/slider_readonly_true-manual.html</a></li>
+<li><a href='#test-file-188'>/wai-aria/slider_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-189'>/wai-aria/spinbutton_all_values_unspecified-manual.html</a></li>
+<li><a href='#test-file-190'>/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html</a></li>
+<li><a href='#test-file-191'>/wai-aria/spinbutton_readonly_false-manual.html</a></li>
+<li><a href='#test-file-192'>/wai-aria/spinbutton_readonly_true-manual.html</a></li>
+<li><a href='#test-file-193'>/wai-aria/spinbutton_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-194'>/wai-aria/switch_checked_false-manual.html</a></li>
+<li><a href='#test-file-195'>/wai-aria/switch_checked_mixed-manual.html</a></li>
+<li><a href='#test-file-196'>/wai-aria/switch_checked_true-manual.html</a></li>
+<li><a href='#test-file-197'>/wai-aria/switch_checked_undefined-manual.html</a></li>
+<li><a href='#test-file-198'>/wai-aria/switch_checked_value_changes-manual.html</a></li>
+<li><a href='#test-file-199'>/wai-aria/switch_readonly_false-manual.html</a></li>
+<li><a href='#test-file-200'>/wai-aria/switch_readonly_true-manual.html</a></li>
+<li><a href='#test-file-201'>/wai-aria/switch_readonly_unspecified-manual.html</a></li>
+<li><a href='#test-file-202'>/wai-aria/tab_posinset_and_setsize-manual.html</a></li>
+<li><a href='#test-file-203'>/wai-aria/table_colcount_-1-manual.html</a></li>
+<li><a href='#test-file-204'>/wai-aria/table_colcount_8-manual.html</a></li>
+<li><a href='#test-file-205'>/wai-aria/table_rowcount_-1-manual.html</a></li>
+<li><a href='#test-file-206'>/wai-aria/table_rowcount_3-manual.html</a></li>
+<li><a href='#test-file-207'>/wai-aria/tablist_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-208'>/wai-aria/tablist_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-209'>/wai-aria/tablist_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-210'>/wai-aria/term_role-manual.html</a></li>
+<li><a href='#test-file-211'>/wai-aria/textbox_placeholder-manual.html</a></li>
+<li><a href='#test-file-212'>/wai-aria/toolbar_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-213'>/wai-aria/toolbar_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-214'>/wai-aria/toolbar_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-215'>/wai-aria/tree_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-216'>/wai-aria/tree_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-217'>/wai-aria/tree_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-218'>/wai-aria/treegrid_colcount_8-manual.html</a></li>
+<li><a href='#test-file-219'>/wai-aria/treegrid_orientation_horizontal-manual.html</a></li>
+<li><a href='#test-file-220'>/wai-aria/treegrid_orientation_unspecified-manual.html</a></li>
+<li><a href='#test-file-221'>/wai-aria/treegrid_orientation_vertical-manual.html</a></li>
+<li><a href='#test-file-222'>/wai-aria/treegrid_rowcount_3-manual.html</a></li>
+<li><a href='#test-file-223'>/wai-aria/treeitem_selected_false-manual.html</a></li>
+<li><a href='#test-file-224'>/wai-aria/treeitem_selected_true-manual.html</a></li>
+<li><a href='#test-file-225'>/wai-aria/treeitem_selected_undefined-manual.html</a></li>
+<li><a href='#test-file-226'>/wai-aria/treeitem_selected_value_changes-manual.html</a></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
@@ -776,7 +780,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 ;  expected true got false</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-33-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-33-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
 <strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'table-cell-index:0', 'tag:td', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px', 'colspan:2'] <br />
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
@@ -786,14 +790,6 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 ; "property AXColumnIndexRange.length is 3" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=3" failed <br />
-<strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
-<a href="https://webkit.org/b/171165">https://webkit.org/b/171165</a>: [NEW] [ATK] atk_table_cell_get_row_column_span() should return values of aria-rowspan and aria-colspan, if present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> 1 <br />
-<a href="https://webkit.org/b/171178">https://webkit.org/b/171178</a>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells <br />
-;  expected true got false</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-34-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3 with headers and border</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
@@ -802,8 +798,16 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-35-0' class='subtest'><td>cell aria-colspan 2 on td with html colspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-35-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3 with three actual columns</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXColumnIndexRange.length is 3" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-36-0' class='subtest'><td>cell aria-colspan 2 on td with html colspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -814,8 +818,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-36-0' class='subtest'><td>cell aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-37-0' class='subtest'><td>cell aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -824,21 +828,25 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-37-0' class='subtest'><td>cell aria-rowspan 2 on td html rowspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-38-0' class='subtest'><td>cell aria-rowspan 2 on td html rowspan 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain rowspan:2" failed <br />
 <strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:cell', 'table-cell-index:0', 'tag:td', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
-; "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=3" failed <br />
-<strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-39'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-39-0' class='subtest'><td>cell aria-rowspan 2 on td html rowspan 3 with three actual rows</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=3" failed <br />
+<strong>Actual value:</strong> (row=1, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 3" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-38-0' class='subtest'><td>cell aria-rowspan 2 on td with html rowspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-40'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-40-0' class='subtest'><td>cell aria-rowspan 2 on td with html rowspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -847,8 +855,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-39'><td><a href='http://www.w3c-test.org/wai-aria/cell_colindex_4-manual.html' target='_blank'>/wai-aria/cell_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-39-0' class='subtest'><td>cell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/wai-aria/cell_colindex_4-manual.html' target='_blank'>/wai-aria/cell_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-41-0' class='subtest'><td>cell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -861,8 +869,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-40'><td><a href='http://www.w3c-test.org/wai-aria/cell_rowindex_4-manual.html' target='_blank'>/wai-aria/cell_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-40-0' class='subtest'><td>cell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/wai-aria/cell_rowindex_4-manual.html' target='_blank'>/wai-aria/cell_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-42-0' class='subtest'><td>cell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -875,14 +883,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_false-manual.html' target='_blank'>/wai-aria/checkbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-41-0' class='subtest'><td>checkbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_false-manual.html' target='_blank'>/wai-aria/checkbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-43-0' class='subtest'><td>checkbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_true-manual.html' target='_blank'>/wai-aria/checkbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-42-0' class='subtest'><td>checkbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-44'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_true-manual.html' target='_blank'>/wai-aria/checkbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-44-0' class='subtest'><td>checkbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
@@ -891,14 +899,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/checkbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-43-0' class='subtest'><td>checkbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/checkbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-45-0' class='subtest'><td>checkbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-44'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-44-0' class='subtest'><td>columnheader aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-46'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-46-0' class='subtest'><td>columnheader aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -907,26 +915,21 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-45-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-47'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-47-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
 <strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'text-indent:0px', 'text-align:center', 'margin-left:0px', 'colspan:2'] <br />
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
+</table></td></tr>
+<tr class='test' id='test-file-48'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-48-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3 with three actual columns</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=3" failed <br />
-<strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
-<a href="https://webkit.org/b/171165">https://webkit.org/b/171165</a>: [NEW] [ATK] atk_table_cell_get_row_column_span() should return values of aria-rowspan and aria-colspan, if present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> 1 <br />
-<a href="https://webkit.org/b/171178">https://webkit.org/b/171178</a>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells <br />
-;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-46'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-46-0' class='subtest'><td>columnheader aria-colspan 2 on th with html colspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-49'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-49-0' class='subtest'><td>columnheader aria-colspan 2 on th with html colspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -935,8 +938,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-47'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-47-0' class='subtest'><td>columnheader aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-50'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-50-0' class='subtest'><td>columnheader aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -945,21 +948,25 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-48'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-48-0' class='subtest'><td>columnheader aria-rowspan 2 on th html rowspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-51'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-51-0' class='subtest'><td>columnheader aria-rowspan 2 on th html rowspan 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain rowspan:2" failed <br />
 <strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:center', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
-; "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=3" failed <br />
-<strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-52-0' class='subtest'><td>columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=3" failed <br />
+<strong>Actual value:</strong> (row=1, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 3" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-49'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-49-0' class='subtest'><td>columnheader aria-rowspan 2 on th with html rowspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-53'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-53-0' class='subtest'><td>columnheader aria-rowspan 2 on th with html rowspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -968,8 +975,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-50'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_colindex_4-manual.html' target='_blank'>/wai-aria/columnheader_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-50-0' class='subtest'><td>columnheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_colindex_4-manual.html' target='_blank'>/wai-aria/columnheader_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-54-0' class='subtest'><td>columnheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -982,8 +989,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-51'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_rowindex_4-manual.html' target='_blank'>/wai-aria/columnheader_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-51-0' class='subtest'><td>columnheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_rowindex_4-manual.html' target='_blank'>/wai-aria/columnheader_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-55-0' class='subtest'><td>columnheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -996,23 +1003,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-52-0' class='subtest'><td>columnheader selected false not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-56'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-56-0' class='subtest'><td>columnheader selected false not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-53'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-53-0' class='subtest'><td>columnheader selected true not automatically propagated</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/wai-aria/combobox_controls_an_invalid_id-manual.html' target='_blank'>/wai-aria/combobox_controls_an_invalid_id-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-54-0' class='subtest'><td>combobox controls an invalid ID</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-57'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-57-0' class='subtest'><td>columnheader selected true not automatically propagated</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-58'><td><a href='http://www.w3c-test.org/wai-aria/combobox_controls_an_invalid_id-manual.html' target='_blank'>/wai-aria/combobox_controls_an_invalid_id-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-58-0' class='subtest'><td>combobox controls an invalid ID</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXLinkedUIElements doesNotContain myID" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-54-1' class='subtest'><td>combobox controls an invalid ID 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_dialog-manual.html' target='_blank'>/wai-aria/combobox_haspopup_dialog-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-55-0' class='subtest'><td>combobox haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-58-1' class='subtest'><td>combobox controls an invalid ID 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_dialog-manual.html' target='_blank'>/wai-aria/combobox_haspopup_dialog-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-59-0' class='subtest'><td>combobox haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -1034,8 +1041,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-56'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_false-manual.html' target='_blank'>/wai-aria/combobox_haspopup_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-56-0' class='subtest'><td>combobox haspopup false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-60'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_false-manual.html' target='_blank'>/wai-aria/combobox_haspopup_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-60-0' class='subtest'><td>combobox haspopup false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -1063,8 +1070,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-57'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_grid-manual.html' target='_blank'>/wai-aria/combobox_haspopup_grid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-57-0' class='subtest'><td>combobox haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-61'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_grid-manual.html' target='_blank'>/wai-aria/combobox_haspopup_grid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-61-0' class='subtest'><td>combobox haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -1086,8 +1093,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-58'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_listbox-manual.html' target='_blank'>/wai-aria/combobox_haspopup_listbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-58-0' class='subtest'><td>combobox haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_listbox-manual.html' target='_blank'>/wai-aria/combobox_haspopup_listbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-62-0' class='subtest'><td>combobox haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -1109,8 +1116,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_menu-manual.html' target='_blank'>/wai-aria/combobox_haspopup_menu-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-59-0' class='subtest'><td>combobox haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-63'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_menu-manual.html' target='_blank'>/wai-aria/combobox_haspopup_menu-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-63-0' class='subtest'><td>combobox haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -1132,8 +1139,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-60'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_tree-manual.html' target='_blank'>/wai-aria/combobox_haspopup_tree-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-60-0' class='subtest'><td>combobox haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-64'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_tree-manual.html' target='_blank'>/wai-aria/combobox_haspopup_tree-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-64-0' class='subtest'><td>combobox haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -1155,8 +1162,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-61'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_true-manual.html' target='_blank'>/wai-aria/combobox_haspopup_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-61-0' class='subtest'><td>combobox haspopup true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-65'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_true-manual.html' target='_blank'>/wai-aria/combobox_haspopup_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-65-0' class='subtest'><td>combobox haspopup true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -1175,8 +1182,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/combobox_haspopup_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-62-0' class='subtest'><td>combobox haspopup unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-66'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/combobox_haspopup_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-66-0' class='subtest'><td>combobox haspopup unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -1198,10 +1205,10 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-63'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_horizontal-manual.html' target='_blank'>/wai-aria/combobox_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-63-0' class='subtest'><td>combobox orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-64'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_unspecified-manual.html' target='_blank'>/wai-aria/combobox_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-64-0' class='subtest'><td>combobox orientation unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-67'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_horizontal-manual.html' target='_blank'>/wai-aria/combobox_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-67-0' class='subtest'><td>combobox orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-68'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_unspecified-manual.html' target='_blank'>/wai-aria/combobox_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-68-0' class='subtest'><td>combobox orientation unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_VERTICAL" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1357042">https://bugzil.la/1357042</a>: [NEW] Implement or update support for exposure of aria-orientation via ATK StateSet <br />
@@ -1210,17 +1217,17 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> AXVerticalOrientation <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-65'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_vertical-manual.html' target='_blank'>/wai-aria/combobox_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-65-0' class='subtest'><td>combobox orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-66'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_false-manual.html' target='_blank'>/wai-aria/combobox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-66-0' class='subtest'><td>combobox readonly false</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-69'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_vertical-manual.html' target='_blank'>/wai-aria/combobox_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-69-0' class='subtest'><td>combobox orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-70'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_false-manual.html' target='_blank'>/wai-aria/combobox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-70-0' class='subtest'><td>combobox readonly false</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-67'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_true-manual.html' target='_blank'>/wai-aria/combobox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-67-0' class='subtest'><td>combobox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-71'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_true-manual.html' target='_blank'>/wai-aria/combobox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-71-0' class='subtest'><td>combobox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS<em>POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -1229,40 +1236,40 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-68'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/combobox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-68-0' class='subtest'><td>combobox readonly unspecified</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-72'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/combobox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-72-0' class='subtest'><td>combobox readonly unspecified</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-69'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_false-manual.html' target='_blank'>/wai-aria/dialog_modal_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-69-0' class='subtest'><td>dialog modal false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-73'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_false-manual.html' target='_blank'>/wai-aria/dialog_modal_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-73-0' class='subtest'><td>dialog modal false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
 <strong>Actual value:</strong> dialog <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-69-1' class='subtest'><td>dialog modal false 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-70'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_true-manual.html' target='_blank'>/wai-aria/dialog_modal_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-70-0' class='subtest'><td>dialog modal true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-73-1' class='subtest'><td>dialog modal false 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_true-manual.html' target='_blank'>/wai-aria/dialog_modal_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-74-0' class='subtest'><td>dialog modal true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
 <strong>Actual value:</strong> dialog <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-70-1' class='subtest'><td>dialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-74-1' class='subtest'><td>dialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-71'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_unspecified-manual.html' target='_blank'>/wai-aria/dialog_modal_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-71-0' class='subtest'><td>dialog modal unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-75'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_unspecified-manual.html' target='_blank'>/wai-aria/dialog_modal_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-75-0' class='subtest'><td>dialog modal unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
 <strong>Actual value:</strong> dialog <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-71-1' class='subtest'><td>dialog modal unspecified 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-72'><td><a href='http://www.w3c-test.org/wai-aria/div_element_without_role_roledescription_valid-manual.html' target='_blank'>/wai-aria/div_element_without_role_roledescription_valid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-72-0' class='subtest'><td>div element without role roledescription valid</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-75-1' class='subtest'><td>dialog modal unspecified 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-76'><td><a href='http://www.w3c-test.org/wai-aria/div_element_without_role_roledescription_valid-manual.html' target='_blank'>/wai-aria/div_element_without_role_roledescription_valid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-76-0' class='subtest'><td>div element without role roledescription valid</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is group" failed <br />
 <strong>Actual value:</strong> foo <br />
 ;  expected true got false</td></tr>
@@ -1270,8 +1277,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> foo <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-73'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-73-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-77-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -1285,7 +1292,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-73-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-77-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -1295,8 +1302,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-mess
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-74-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-78-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -1310,7 +1317,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-74-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-78-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -1320,8 +1327,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-mess
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-75'><td><a href='http://www.w3c-test.org/wai-aria/feed-manual.html' target='_blank'>/wai-aria/feed-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-75-0' class='subtest'><td>feed</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-79'><td><a href='http://www.w3c-test.org/wai-aria/feed-manual.html' target='_blank'>/wai-aria/feed-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-79-0' class='subtest'><td>feed</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXGroup" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: Object not found <br />
@@ -1333,50 +1340,50 @@ ERROR: Object not found <br />
 ERROR: Object not found <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-76'><td><a href='http://www.w3c-test.org/wai-aria/figure-manual.html' target='_blank'>/wai-aria/figure-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-76-0' class='subtest'><td>figure</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-80'><td><a href='http://www.w3c-test.org/wai-aria/figure-manual.html' target='_blank'>/wai-aria/figure-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-80-0' class='subtest'><td>figure</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_PANEL" failed <br />
 <strong>Actual value:</strong> ROLE_SECTION <br />
 <a href="https://bugzil.la/1356049">https://bugzil.la/1356049</a>: [NEW] ARIA figure role should be mapped as ATK_ROLE_PANEL <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html' target='_blank'>/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-77-0' class='subtest'><td>grid aria-readonly false automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-81'><td><a href='http://www.w3c-test.org/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html' target='_blank'>/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-81-0' class='subtest'><td>grid aria-readonly false automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-77-1' class='subtest'><td>grid aria-readonly false automatically propagated 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-81-1' class='subtest'><td>grid aria-readonly false automatically propagated 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-77-2' class='subtest'><td>grid aria-readonly false automatically propagated 2</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-81-2' class='subtest'><td>grid aria-readonly false automatically propagated 2</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html' target='_blank'>/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-78-0' class='subtest'><td>grid aria-readonly true automatically propagated</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-82'><td><a href='http://www.w3c-test.org/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html' target='_blank'>/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-82-0' class='subtest'><td>grid aria-readonly true automatically propagated</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SELECTABLE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-78-1' class='subtest'><td>grid aria-readonly true automatically propagated 1</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-82-1' class='subtest'><td>grid aria-readonly true automatically propagated 1</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-78-2' class='subtest'><td>grid aria-readonly true automatically propagated 2</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-82-2' class='subtest'><td>grid aria-readonly true automatically propagated 2</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-79'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_false-manual.html' target='_blank'>/wai-aria/grid_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-79-0' class='subtest'><td>grid busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-83'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_false-manual.html' target='_blank'>/wai-aria/grid_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-83-0' class='subtest'><td>grid busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
 ; "property AXRoleDescription is table" failed <br />
@@ -1385,8 +1392,8 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-80'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_true-manual.html' target='_blank'>/wai-aria/grid_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-80-0' class='subtest'><td>grid busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-84'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_true-manual.html' target='_blank'>/wai-aria/grid_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-84-0' class='subtest'><td>grid busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
 ; "property AXRoleDescription is table" failed <br />
@@ -1395,8 +1402,8 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-81'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_value_changes-manual.html' target='_blank'>/wai-aria/grid_busy_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-81-0' class='subtest'><td>grid busy value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-85'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_value_changes-manual.html' target='_blank'>/wai-aria/grid_busy_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-85-0' class='subtest'><td>grid busy value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXElementBusyChanged" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
 ; "property AXSubrole is <nil>" failed <br />
@@ -1406,8 +1413,8 @@ ERROR: Object not found <br />
 ; "property AXElementBusy is true" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-82'><td><a href='http://www.w3c-test.org/wai-aria/grid_colcount_8-manual.html' target='_blank'>/wai-aria/grid_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-82-0' class='subtest'><td>grid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/wai-aria/grid_colcount_8-manual.html' target='_blank'>/wai-aria/grid_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-86-0' class='subtest'><td>grid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -1420,33 +1427,33 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-83'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_false-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-83-0' class='subtest'><td>grid columnheader readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-87'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_false-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-87-0' class='subtest'><td>grid columnheader readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-84'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_true-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-84-0' class='subtest'><td>grid columnheader readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-88'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_true-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-88-0' class='subtest'><td>grid columnheader readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-85'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_unspecified-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-85-0' class='subtest'><td>grid columnheader readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-89'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_unspecified-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-89-0' class='subtest'><td>grid columnheader readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_false-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-86-0' class='subtest'><td>grid columnheader required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-87'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_true-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-87-0' class='subtest'><td>grid columnheader required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-88'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_unspecified-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-88-0' class='subtest'><td>grid columnheader required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-89'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowcount_3-manual.html' target='_blank'>/wai-aria/grid_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-89-0' class='subtest'><td>grid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-90'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_false-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-90-0' class='subtest'><td>grid columnheader required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-91'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_true-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-91-0' class='subtest'><td>grid columnheader required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-92'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_unspecified-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-92-0' class='subtest'><td>grid columnheader required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-93'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowcount_3-manual.html' target='_blank'>/wai-aria/grid_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-93-0' class='subtest'><td>grid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -1459,33 +1466,33 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-90'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_false-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-90-0' class='subtest'><td>grid rowheader readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-94'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_false-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-94-0' class='subtest'><td>grid rowheader readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-91'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_true-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-91-0' class='subtest'><td>grid rowheader readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-95'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_true-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-95-0' class='subtest'><td>grid rowheader readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-92'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_unspecified-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-92-0' class='subtest'><td>grid rowheader readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-96'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_unspecified-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-96-0' class='subtest'><td>grid rowheader readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-93'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_false-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-93-0' class='subtest'><td>grid rowheader required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-94'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_true-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-94-0' class='subtest'><td>grid rowheader required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-95'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_unspecified-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-95-0' class='subtest'><td>grid rowheader required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-96'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/gridcell_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-96-0' class='subtest'><td>gridcell aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-97'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_false-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-97-0' class='subtest'><td>grid rowheader required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-98'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_true-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-98-0' class='subtest'><td>grid rowheader required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-99'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_unspecified-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-99-0' class='subtest'><td>grid rowheader required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-100'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/gridcell_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-100-0' class='subtest'><td>gridcell aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -1494,8 +1501,8 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-97'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-97-0' class='subtest'><td>gridcell aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-101'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-101-0' class='subtest'><td>gridcell aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -1504,8 +1511,8 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-98'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_colindex_4-manual.html' target='_blank'>/wai-aria/gridcell_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-98-0' class='subtest'><td>gridcell colindex 4</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-102'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_colindex_4-manual.html' target='_blank'>/wai-aria/gridcell_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-102-0' class='subtest'><td>gridcell colindex 4</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -1515,8 +1522,8 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-99'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_rowindex_4-manual.html' target='_blank'>/wai-aria/gridcell_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-99-0' class='subtest'><td>gridcell rowindex 4</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-103'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_rowindex_4-manual.html' target='_blank'>/wai-aria/gridcell_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-103-0' class='subtest'><td>gridcell rowindex 4</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -1526,16 +1533,16 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-100'><td><a href='http://www.w3c-test.org/wai-aria/group_hidden_undefined_element_not_rendered-manual.html' target='_blank'>/wai-aria/group_hidden_undefined_element_not_rendered-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-100-0' class='subtest'><td>group hidden undefined element not rendered</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-101'><td><a href='http://www.w3c-test.org/wai-aria/group_hidden_undefined_element_rendered-manual.html' target='_blank'>/wai-aria/group_hidden_undefined_element_rendered-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-101-0' class='subtest'><td>group hidden undefined element rendered</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-104'><td><a href='http://www.w3c-test.org/wai-aria/group_hidden_undefined_element_not_rendered-manual.html' target='_blank'>/wai-aria/group_hidden_undefined_element_not_rendered-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-104-0' class='subtest'><td>group hidden undefined element not rendered</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-105'><td><a href='http://www.w3c-test.org/wai-aria/group_hidden_undefined_element_rendered-manual.html' target='_blank'>/wai-aria/group_hidden_undefined_element_rendered-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-105-0' class='subtest'><td>group hidden undefined element rendered</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-102'><td><a href='http://www.w3c-test.org/wai-aria/heading_level_unspecified-manual.html' target='_blank'>/wai-aria/heading_level_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-102-0' class='subtest'><td>heading level unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-106'><td><a href='http://www.w3c-test.org/wai-aria/heading_level_unspecified-manual.html' target='_blank'>/wai-aria/heading_level_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-106-0' class='subtest'><td>heading level unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains level:2" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:heading', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1357100">https://bugzil.la/1357100</a>: [NEW] Implement support for implicit value for aria-level on heading role <br />
@@ -1544,8 +1551,8 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-103'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_multiple_shortcuts-manual.html' target='_blank'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-103-0' class='subtest'><td>keyshortcuts multiple shortcuts</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-107'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_multiple_shortcuts-manual.html' target='_blank'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-107-0' class='subtest'><td>keyshortcuts multiple shortcuts</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
@@ -1562,8 +1569,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/159215">https://webkit.org/b/159215</a>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-104'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_one_shortcut-manual.html' target='_blank'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-104-0' class='subtest'><td>keyshortcuts one shortcut</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-108'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_one_shortcut-manual.html' target='_blank'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-108-0' class='subtest'><td>keyshortcuts one shortcut</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
@@ -1580,45 +1587,45 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/159215">https://webkit.org/b/159215</a>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-105'><td><a href='http://www.w3c-test.org/wai-aria/listbox_busy_false-manual.html' target='_blank'>/wai-aria/listbox_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-105-0' class='subtest'><td>listbox busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-109'><td><a href='http://www.w3c-test.org/wai-aria/listbox_busy_false-manual.html' target='_blank'>/wai-aria/listbox_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-109-0' class='subtest'><td>listbox busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-106'><td><a href='http://www.w3c-test.org/wai-aria/listbox_busy_true-manual.html' target='_blank'>/wai-aria/listbox_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-106-0' class='subtest'><td>listbox busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-110'><td><a href='http://www.w3c-test.org/wai-aria/listbox_busy_true-manual.html' target='_blank'>/wai-aria/listbox_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-110-0' class='subtest'><td>listbox busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-107'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_horizontal-manual.html' target='_blank'>/wai-aria/listbox_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-107-0' class='subtest'><td>listbox orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-108'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_unspecified-manual.html' target='_blank'>/wai-aria/listbox_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-108-0' class='subtest'><td>listbox orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-109'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_vertical-manual.html' target='_blank'>/wai-aria/listbox_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-109-0' class='subtest'><td>listbox orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-110'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_false-manual.html' target='_blank'>/wai-aria/listbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-110-0' class='subtest'><td>listbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-111'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_horizontal-manual.html' target='_blank'>/wai-aria/listbox_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-111-0' class='subtest'><td>listbox orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-112'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_unspecified-manual.html' target='_blank'>/wai-aria/listbox_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-112-0' class='subtest'><td>listbox orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-113'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_vertical-manual.html' target='_blank'>/wai-aria/listbox_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-113-0' class='subtest'><td>listbox orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-114'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_false-manual.html' target='_blank'>/wai-aria/listbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-114-0' class='subtest'><td>listbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-111'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_true-manual.html' target='_blank'>/wai-aria/listbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-111-0' class='subtest'><td>listbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-115'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_true-manual.html' target='_blank'>/wai-aria/listbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-115-0' class='subtest'><td>listbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-112'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/listbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-112-0' class='subtest'><td>listbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-116'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/listbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-116-0' class='subtest'><td>listbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-113'><td><a href='http://www.w3c-test.org/wai-aria/listitem_setsize_-1-manual.html' target='_blank'>/wai-aria/listitem_setsize_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-113-0' class='subtest'><td>listitem setsize -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-117'><td><a href='http://www.w3c-test.org/wai-aria/listitem_setsize_-1-manual.html' target='_blank'>/wai-aria/listitem_setsize_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-117-0' class='subtest'><td>listitem setsize -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains setsize:-1" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'posinset:1', 'margin-top:0px', 'xml-roles:listitem', 'tag:div', 'id:test', 'setsize:1', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1358473">https://bugzil.la/1358473</a>: [NEW] Do not calculate setsize when aria-setsize has a value of -1 <br />
@@ -1627,75 +1634,75 @@ ERROR: 'NoneType' object is not callable <br />
 <strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-114'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_horizontal-manual.html' target='_blank'>/wai-aria/menu_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-114-0' class='subtest'><td>menu orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-115'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_unspecified-manual.html' target='_blank'>/wai-aria/menu_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-115-0' class='subtest'><td>menu orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-116'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_vertical-manual.html' target='_blank'>/wai-aria/menu_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-116-0' class='subtest'><td>menu orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-117'><td><a href='http://www.w3c-test.org/wai-aria/menubar_busy_false-manual.html' target='_blank'>/wai-aria/menubar_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-117-0' class='subtest'><td>menubar busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-118'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_horizontal-manual.html' target='_blank'>/wai-aria/menu_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-118-0' class='subtest'><td>menu orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-119'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_unspecified-manual.html' target='_blank'>/wai-aria/menu_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-119-0' class='subtest'><td>menu orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-120'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_vertical-manual.html' target='_blank'>/wai-aria/menu_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-120-0' class='subtest'><td>menu orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-121'><td><a href='http://www.w3c-test.org/wai-aria/menubar_busy_false-manual.html' target='_blank'>/wai-aria/menubar_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-121-0' class='subtest'><td>menubar busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-118'><td><a href='http://www.w3c-test.org/wai-aria/menubar_busy_true-manual.html' target='_blank'>/wai-aria/menubar_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-118-0' class='subtest'><td>menubar busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-122'><td><a href='http://www.w3c-test.org/wai-aria/menubar_busy_true-manual.html' target='_blank'>/wai-aria/menubar_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-122-0' class='subtest'><td>menubar busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-119'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_horizontal-manual.html' target='_blank'>/wai-aria/menubar_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-119-0' class='subtest'><td>menubar orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-120'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/menubar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-120-0' class='subtest'><td>menubar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-121'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_vertical-manual.html' target='_blank'>/wai-aria/menubar_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-121-0' class='subtest'><td>menubar orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-122'><td><a href='http://www.w3c-test.org/wai-aria/menuitem_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitem_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-122-0' class='subtest'><td>menuitem posinset and setsize</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-123'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-123-0' class='subtest'><td>menuitemcheckbox posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-123'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_horizontal-manual.html' target='_blank'>/wai-aria/menubar_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-123-0' class='subtest'><td>menubar orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-124'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/menubar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-124-0' class='subtest'><td>menubar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-125'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_vertical-manual.html' target='_blank'>/wai-aria/menubar_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-125-0' class='subtest'><td>menubar orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-126'><td><a href='http://www.w3c-test.org/wai-aria/menuitem_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitem_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-126-0' class='subtest'><td>menuitem posinset and setsize</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-127'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-127-0' class='subtest'><td>menuitemcheckbox posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ; "property AXARIASetSize is 8" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-124'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_false-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-124-0' class='subtest'><td>menuitemcheckbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-128'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_false-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-128-0' class='subtest'><td>menuitemcheckbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-125'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_true-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-125-0' class='subtest'><td>menuitemcheckbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-129'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_true-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-129-0' class='subtest'><td>menuitemcheckbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-126'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-126-0' class='subtest'><td>menuitemcheckbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-130'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-130-0' class='subtest'><td>menuitemcheckbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-127'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitemradio_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-127-0' class='subtest'><td>menuitemradio posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-131'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitemradio_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-131-0' class='subtest'><td>menuitemradio posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ; "property AXARIASetSize is 8" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-128'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_false-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-128-0' class='subtest'><td>menuitemradio readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-132'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_false-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-132-0' class='subtest'><td>menuitemradio readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-129'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_true-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-129-0' class='subtest'><td>menuitemradio readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-133'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_true-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-133-0' class='subtest'><td>menuitemradio readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
@@ -1704,23 +1711,23 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-130'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_unspecified-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-130-0' class='subtest'><td>menuitemradio readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-134'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_unspecified-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-134-0' class='subtest'><td>menuitemradio readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-131'><td><a href='http://www.w3c-test.org/wai-aria/none-manual.html' target='_blank'>/wai-aria/none-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-131-0' class='subtest'><td>none</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-132'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_false-manual.html' target='_blank'>/wai-aria/option_selected_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-132-0' class='subtest'><td>option selected false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/wai-aria/none-manual.html' target='_blank'>/wai-aria/none-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-135-0' class='subtest'><td>none</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-136'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_false-manual.html' target='_blank'>/wai-aria/option_selected_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-136-0' class='subtest'><td>option selected false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_SELECTABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE'] <br />
 <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a>: [NEW] [ATK] Options in an ARIA listbox should have STATE_SELECTABLE and emit selection-related events <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-133'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_true-manual.html' target='_blank'>/wai-aria/option_selected_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-133-0' class='subtest'><td>option selected true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-137'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_true-manual.html' target='_blank'>/wai-aria/option_selected_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-137-0' class='subtest'><td>option selected true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
@@ -1729,15 +1736,15 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a>: [NEW] [ATK] Options in an ARIA listbox should have STATE_SELECTABLE and emit selection-related events <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-134'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_undefined-manual.html' target='_blank'>/wai-aria/option_selected_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-134-0' class='subtest'><td>option selected undefined</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-138'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_undefined-manual.html' target='_blank'>/wai-aria/option_selected_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-138-0' class='subtest'><td>option selected undefined</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_SELECTABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE'] <br />
 <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a>: [NEW] [ATK] Options in an ARIA listbox should have STATE_SELECTABLE and emit selection-related events <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_value_changes-manual.html' target='_blank'>/wai-aria/option_selected_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-135-0' class='subtest'><td>option selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-139'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_value_changes-manual.html' target='_blank'>/wai-aria/option_selected_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-139-0' class='subtest'><td>option selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
@@ -1745,47 +1752,47 @@ ERROR: 'NoneType' object is not callable <br />
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-135-1' class='subtest'><td>option selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-139-1' class='subtest'><td>option selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:selection-changed" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-135-2' class='subtest'><td>option selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-139-2' class='subtest'><td>option selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-136'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_horizontal-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-136-0' class='subtest'><td>radiogroup orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-137'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_unspecified-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-137-0' class='subtest'><td>radiogroup orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-140'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_horizontal-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-140-0' class='subtest'><td>radiogroup orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-141'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_unspecified-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-141-0' class='subtest'><td>radiogroup orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXOrientation is AXUnknownOrientation" failed <br />
 <strong>Actual value:</strong> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-138'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_vertical-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-138-0' class='subtest'><td>radiogroup orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-139'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_false-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-139-0' class='subtest'><td>radiogroup readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-142'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_vertical-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-142-0' class='subtest'><td>radiogroup orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-143'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_false-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-143-0' class='subtest'><td>radiogroup readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-140'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_true-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-140-0' class='subtest'><td>radiogroup readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-144'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_true-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-144-0' class='subtest'><td>radiogroup readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-141'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_unspecified-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-141-0' class='subtest'><td>radiogroup readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-145'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_unspecified-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-145-0' class='subtest'><td>radiogroup readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-142'><td><a href='http://www.w3c-test.org/wai-aria/region_with_name-manual.html' target='_blank'>/wai-aria/region_with_name-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-142-0' class='subtest'><td>region with name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-146'><td><a href='http://www.w3c-test.org/wai-aria/region_with_name-manual.html' target='_blank'>/wai-aria/region_with_name-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-146-0' class='subtest'><td>region with name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_LANDMARK" failed <br />
 <strong>Actual value:</strong> ROLE_PANEL <br />
 <a href="https://bugzil.la/1210630">https://bugzil.la/1210630</a>: [NEW] Section elements with accessible names should be mapped the same as ARIA role region <br />
@@ -1794,8 +1801,8 @@ ERROR: 'NoneType' object is not callable <br />
 <strong>Actual value:</strong> AXDocumentRegion <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-143'><td><a href='http://www.w3c-test.org/wai-aria/region_without_name-manual.html' target='_blank'>/wai-aria/region_without_name-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-143-0' class='subtest'><td>region without name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-147'><td><a href='http://www.w3c-test.org/wai-aria/region_without_name-manual.html' target='_blank'>/wai-aria/region_without_name-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-147-0' class='subtest'><td>region without name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_SECTION" failed <br />
 <strong>Actual value:</strong> ROLE_PANEL <br />
 <a href="https://bugzil.la/1358462">https://bugzil.la/1358462</a>: [NEW] Elements with role="region" and no accessible name should be mapped according to host language <br />
@@ -1806,14 +1813,14 @@ ERROR: 'NoneType' object is not callable <br />
 <strong>Actual value:</strong> region <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-144'><td><a href='http://www.w3c-test.org/wai-aria/row_colindex_4-manual.html' target='_blank'>/wai-aria/row_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-144-0' class='subtest'><td>row colindex 4</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-148'><td><a href='http://www.w3c-test.org/wai-aria/row_colindex_4-manual.html' target='_blank'>/wai-aria/row_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-148-0' class='subtest'><td>row colindex 4</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains colindex:4" failed <br />
 <strong>Actual value:</strong> ['computed-role:row', 'xml-roles:row', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk'] <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-144-1' class='subtest'><td>row colindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-148-1' class='subtest'><td>row colindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -1826,14 +1833,14 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-145'><td><a href='http://www.w3c-test.org/wai-aria/row_rowindex_4-manual.html' target='_blank'>/wai-aria/row_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-145-0' class='subtest'><td>row rowindex 4</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-149'><td><a href='http://www.w3c-test.org/wai-aria/row_rowindex_4-manual.html' target='_blank'>/wai-aria/row_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-149-0' class='subtest'><td>row rowindex 4</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains rowindex:4" failed <br />
 <strong>Actual value:</strong> ['computed-role:row', 'xml-roles:row', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk'] <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-145-1' class='subtest'><td>row rowindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-149-1' class='subtest'><td>row rowindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -1846,8 +1853,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-146'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/rowheader_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-146-0' class='subtest'><td>rowheader aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-150'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/rowheader_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-150-0' class='subtest'><td>rowheader aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -1856,8 +1863,8 @@ ERROR: 'NoneType' object is not callable <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-147'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-147-0' class='subtest'><td>rowheader aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-151'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-151-0' class='subtest'><td>rowheader aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
@@ -1866,8 +1873,8 @@ ERROR: 'NoneType' object is not callable <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-148'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_colindex_4-manual.html' target='_blank'>/wai-aria/rowheader_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-148-0' class='subtest'><td>rowheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-152'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_colindex_4-manual.html' target='_blank'>/wai-aria/rowheader_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-152-0' class='subtest'><td>rowheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -1880,8 +1887,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-149'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_rowindex_4-manual.html' target='_blank'>/wai-aria/rowheader_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-149-0' class='subtest'><td>rowheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-153'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_rowindex_4-manual.html' target='_blank'>/wai-aria/rowheader_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-153-0' class='subtest'><td>rowheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -1894,16 +1901,16 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-150'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-150-0' class='subtest'><td>rowheader selected false not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-154'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-154-0' class='subtest'><td>rowheader selected false not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-151'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-151-0' class='subtest'><td>rowheader selected true not automatically propagated</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-152'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_all_values_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-152-0' class='subtest'><td>scrollbar all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-155'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-155-0' class='subtest'><td>rowheader selected true not automatically propagated</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-156'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_all_values_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-156-0' class='subtest'><td>scrollbar all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() is 0" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: atspi_error: Get failed (1) <br />
@@ -1921,8 +1928,8 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-153'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-153-0' class='subtest'><td>scrollbar only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-157'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-157-0' class='subtest'><td>scrollbar only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>current</em>value() is 20" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 <a href="https://bugzil.la/1357071">https://bugzil.la/1357071</a>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles <br />
@@ -1931,16 +1938,16 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-154'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-154-0' class='subtest'><td>scrollbar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-155'><td><a href='http://www.w3c-test.org/wai-aria/searchbox-manual.html' target='_blank'>/wai-aria/searchbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-155-0' class='subtest'><td>searchbox</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-158'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-158-0' class='subtest'><td>scrollbar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-159'><td><a href='http://www.w3c-test.org/wai-aria/searchbox-manual.html' target='_blank'>/wai-aria/searchbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-159-0' class='subtest'><td>searchbox</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
 <strong>Actual value:</strong> AXTextArea <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-156'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-156-0' class='subtest'><td>searchbox activedescendant</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-160-0' class='subtest'><td>searchbox activedescendant</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states doesNotContain STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_EDITABLE', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_FOCUSED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_SINGLE_LINE', 'STATE_VISIBLE'] <br />
 ;  expected true got false</td></tr>
@@ -1948,7 +1955,7 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-156-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 ; "property states contains STATE_FOCUSABLE" failed <br />
@@ -1974,8 +1981,8 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-157'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-157-0' class='subtest'><td>searchbox activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-161-0' class='subtest'><td>searchbox activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result array isNot true" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states doesNotContain STATE_FOCUSED" failed <br />
@@ -1986,7 +1993,7 @@ ERROR: Object not found <br />
 ; "result array isNot true" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-157-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 ; "property states contains STATE_FOCUSABLE" failed <br />
@@ -2012,36 +2019,36 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-158'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_both-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_both-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-158-0' class='subtest'><td>searchbox autocomplete both</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-159'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_inline-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_inline-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-159-0' class='subtest'><td>searchbox autocomplete inline</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_list-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_list-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-160-0' class='subtest'><td>searchbox autocomplete list</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_none-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_none-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-161-0' class='subtest'><td>searchbox autocomplete none</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-162'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-162-0' class='subtest'><td>searchbox autocomplete unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-163'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_false-manual.html' target='_blank'>/wai-aria/searchbox_multiline_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-163-0' class='subtest'><td>searchbox multiline false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-162'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_both-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_both-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-162-0' class='subtest'><td>searchbox autocomplete both</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-163'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_inline-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_inline-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-163-0' class='subtest'><td>searchbox autocomplete inline</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-164'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_list-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_list-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-164-0' class='subtest'><td>searchbox autocomplete list</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-165'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_none-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_none-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-165-0' class='subtest'><td>searchbox autocomplete none</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-166'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-166-0' class='subtest'><td>searchbox autocomplete unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-167'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_false-manual.html' target='_blank'>/wai-aria/searchbox_multiline_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-167-0' class='subtest'><td>searchbox multiline false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
 <strong>Actual value:</strong> AXTextArea <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-164'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_true-manual.html' target='_blank'>/wai-aria/searchbox_multiline_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-164-0' class='subtest'><td>searchbox multiline true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-168'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_true-manual.html' target='_blank'>/wai-aria/searchbox_multiline_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-168-0' class='subtest'><td>searchbox multiline true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
 <strong>Actual value:</strong> AXTextArea <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-165'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_multiline_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-165-0' class='subtest'><td>searchbox multiline unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-169'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_multiline_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-169-0' class='subtest'><td>searchbox multiline unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
 <strong>Actual value:</strong> AXTextArea <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-166'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_placeholder-manual.html' target='_blank'>/wai-aria/searchbox_placeholder-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-166-0' class='subtest'><td>searchbox placeholder</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-170'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_placeholder-manual.html' target='_blank'>/wai-aria/searchbox_placeholder-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-170-0' class='subtest'><td>searchbox placeholder</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains placeholder-text:DD/MM/YYYY" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'placeholder:DD/MM/YYYY', 'margin-top:0px', 'xml-roles:searchbox', 'text-input-type:search', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1303429">https://bugzil.la/1303429</a>: [NEW] expose placeholder object attribute for HTML placeholder <br />
@@ -2050,10 +2057,10 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> AXTextArea <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-167'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_false-manual.html' target='_blank'>/wai-aria/searchbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-167-0' class='subtest'><td>searchbox readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-168'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_true-manual.html' target='_blank'>/wai-aria/searchbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-168-0' class='subtest'><td>searchbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-171'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_false-manual.html' target='_blank'>/wai-aria/searchbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-171-0' class='subtest'><td>searchbox readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-172'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_true-manual.html' target='_blank'>/wai-aria/searchbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-172-0' class='subtest'><td>searchbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces doesNotContain EditableText" failed <br />
 <strong>Actual value:</strong> ['Accessible', 'Action', 'Collection', 'Component', 'EditableText', 'Hypertext', 'Hyperlink', 'Text'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
@@ -2062,16 +2069,16 @@ ERROR: Object not found <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-169'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-169-0' class='subtest'><td>searchbox readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-170'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_false-manual.html' target='_blank'>/wai-aria/searchbox_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-170-0' class='subtest'><td>searchbox required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-171'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_true-manual.html' target='_blank'>/wai-aria/searchbox_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-171-0' class='subtest'><td>searchbox required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-172'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-172-0' class='subtest'><td>searchbox required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-173'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_all_values_unspecified-manual.html' target='_blank'>/wai-aria/separator_focusable_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-173-0' class='subtest'><td>separator focusable all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-173'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-173-0' class='subtest'><td>searchbox readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-174'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_false-manual.html' target='_blank'>/wai-aria/searchbox_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-174-0' class='subtest'><td>searchbox required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-175'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_true-manual.html' target='_blank'>/wai-aria/searchbox_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-175-0' class='subtest'><td>searchbox required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-176'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-176-0' class='subtest'><td>searchbox required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-177'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_all_values_unspecified-manual.html' target='_blank'>/wai-aria/separator_focusable_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-177-0' class='subtest'><td>separator focusable all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces contains Value" failed <br />
 <strong>Actual value:</strong> ['Accessible', 'Collection', 'Component', 'Hyperlink'] <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
@@ -2094,8 +2101,8 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-174'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-174-0' class='subtest'><td>separator focusable only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-178'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-178-0' class='subtest'><td>separator focusable only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces contains Value" failed <br />
 <strong>Actual value:</strong> ['Accessible', 'Collection', 'Component', 'Hyperlink'] <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
@@ -2118,8 +2125,8 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-175'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_valuetext-manual.html' target='_blank'>/wai-aria/separator_focusable_valuetext-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-175-0' class='subtest'><td>separator focusable valuetext</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-179'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_valuetext-manual.html' target='_blank'>/wai-aria/separator_focusable_valuetext-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-179-0' class='subtest'><td>separator focusable valuetext</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains valuetext:Bonaire" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:separator', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
@@ -2147,14 +2154,14 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-176'><td><a href='http://www.w3c-test.org/wai-aria/separator_orientation_unspecified-manual.html' target='_blank'>/wai-aria/separator_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-176-0' class='subtest'><td>separator orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-177'><td><a href='http://www.w3c-test.org/wai-aria/separator_unfocusable_all_values_unspecified-manual.html' target='_blank'>/wai-aria/separator_unfocusable_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-177-0' class='subtest'><td>separator unfocusable all values unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-178'><td><a href='http://www.w3c-test.org/wai-aria/separator_unfocusable_valuetext-manual.html' target='_blank'>/wai-aria/separator_unfocusable_valuetext-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-178-0' class='subtest'><td>separator unfocusable valuetext</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-179'><td><a href='http://www.w3c-test.org/wai-aria/slider_all_values_unspecified-manual.html' target='_blank'>/wai-aria/slider_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-179-0' class='subtest'><td>slider all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-180'><td><a href='http://www.w3c-test.org/wai-aria/separator_orientation_unspecified-manual.html' target='_blank'>/wai-aria/separator_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-180-0' class='subtest'><td>separator orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-181'><td><a href='http://www.w3c-test.org/wai-aria/separator_unfocusable_all_values_unspecified-manual.html' target='_blank'>/wai-aria/separator_unfocusable_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-181-0' class='subtest'><td>separator unfocusable all values unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-182'><td><a href='http://www.w3c-test.org/wai-aria/separator_unfocusable_valuetext-manual.html' target='_blank'>/wai-aria/separator_unfocusable_valuetext-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-182-0' class='subtest'><td>separator unfocusable valuetext</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-183'><td><a href='http://www.w3c-test.org/wai-aria/slider_all_values_unspecified-manual.html' target='_blank'>/wai-aria/slider_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-183-0' class='subtest'><td>slider all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() is 0" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: atspi_error: Get failed (1) <br />
@@ -2172,8 +2179,8 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-180'><td><a href='http://www.w3c-test.org/wai-aria/slider_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/slider_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-180-0' class='subtest'><td>slider only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-184'><td><a href='http://www.w3c-test.org/wai-aria/slider_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/slider_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-184-0' class='subtest'><td>slider only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>current</em>value() is 20" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 <a href="https://bugzil.la/1357071">https://bugzil.la/1357071</a>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles <br />
@@ -2182,21 +2189,21 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-181'><td><a href='http://www.w3c-test.org/wai-aria/slider_orientation_unspecified-manual.html' target='_blank'>/wai-aria/slider_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-181-0' class='subtest'><td>slider orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-182'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_false-manual.html' target='_blank'>/wai-aria/slider_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-182-0' class='subtest'><td>slider readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-183'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_true-manual.html' target='_blank'>/wai-aria/slider_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-183-0' class='subtest'><td>slider readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-185'><td><a href='http://www.w3c-test.org/wai-aria/slider_orientation_unspecified-manual.html' target='_blank'>/wai-aria/slider_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-185-0' class='subtest'><td>slider orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-186'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_false-manual.html' target='_blank'>/wai-aria/slider_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-186-0' class='subtest'><td>slider readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-187'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_true-manual.html' target='_blank'>/wai-aria/slider_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-187-0' class='subtest'><td>slider readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-184'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_unspecified-manual.html' target='_blank'>/wai-aria/slider_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-184-0' class='subtest'><td>slider readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-185'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_all_values_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-185-0' class='subtest'><td>spinbutton all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-188'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_unspecified-manual.html' target='_blank'>/wai-aria/slider_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-188-0' class='subtest'><td>slider readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-189'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_all_values_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-189-0' class='subtest'><td>spinbutton all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() isLTE -9007199254740992" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: atspi_error: Get failed (1) <br />
@@ -2211,55 +2218,55 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-186'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-186-0' class='subtest'><td>spinbutton only aria-valuenow unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-187'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_false-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-187-0' class='subtest'><td>spinbutton readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-188'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_true-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-188-0' class='subtest'><td>spinbutton readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-190'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-190-0' class='subtest'><td>spinbutton only aria-valuenow unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-191'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_false-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-191-0' class='subtest'><td>spinbutton readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-192'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_true-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-192-0' class='subtest'><td>spinbutton readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-189'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-189-0' class='subtest'><td>spinbutton readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-190'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_false-manual.html' target='_blank'>/wai-aria/switch_checked_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-190-0' class='subtest'><td>switch checked false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-191'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_mixed-manual.html' target='_blank'>/wai-aria/switch_checked_mixed-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-191-0' class='subtest'><td>switch checked mixed</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-193'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-193-0' class='subtest'><td>spinbutton readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-194'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_false-manual.html' target='_blank'>/wai-aria/switch_checked_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-194-0' class='subtest'><td>switch checked false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-195'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_mixed-manual.html' target='_blank'>/wai-aria/switch_checked_mixed-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-195-0' class='subtest'><td>switch checked mixed</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKED" failed <br />
 <strong>Actual value:</strong> ['STATE_CHECKED', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1358447">https://bugzil.la/1358447</a>: [NEW] Elements with aria-checked="mixed" and role="switch" should not expose ATK_STATE_CHECKED <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-192'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_true-manual.html' target='_blank'>/wai-aria/switch_checked_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-192-0' class='subtest'><td>switch checked true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-193'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_undefined-manual.html' target='_blank'>/wai-aria/switch_checked_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-193-0' class='subtest'><td>switch checked undefined</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-194'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_value_changes-manual.html' target='_blank'>/wai-aria/switch_checked_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-194-0' class='subtest'><td>switch checked value changes</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-195'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_false-manual.html' target='_blank'>/wai-aria/switch_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-195-0' class='subtest'><td>switch readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-196'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_true-manual.html' target='_blank'>/wai-aria/switch_checked_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-196-0' class='subtest'><td>switch checked true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-197'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_undefined-manual.html' target='_blank'>/wai-aria/switch_checked_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-197-0' class='subtest'><td>switch checked undefined</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-198'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_value_changes-manual.html' target='_blank'>/wai-aria/switch_checked_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-198-0' class='subtest'><td>switch checked value changes</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-199'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_false-manual.html' target='_blank'>/wai-aria/switch_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-199-0' class='subtest'><td>switch readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-196'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_true-manual.html' target='_blank'>/wai-aria/switch_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-196-0' class='subtest'><td>switch readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-200'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_true-manual.html' target='_blank'>/wai-aria/switch_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-200-0' class='subtest'><td>switch readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-197'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_unspecified-manual.html' target='_blank'>/wai-aria/switch_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-197-0' class='subtest'><td>switch readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-201'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_unspecified-manual.html' target='_blank'>/wai-aria/switch_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-201-0' class='subtest'><td>switch readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-198'><td><a href='http://www.w3c-test.org/wai-aria/tab_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/tab_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-198-0' class='subtest'><td>tab posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-202'><td><a href='http://www.w3c-test.org/wai-aria/tab_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/tab_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-202-0' class='subtest'><td>tab posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 3" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ; "property AXARIASetSize is 7" failed <br />
@@ -2268,8 +2275,8 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-199'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_-1-manual.html' target='_blank'>/wai-aria/table_colcount_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-199-0' class='subtest'><td>table colcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-203'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_-1-manual.html' target='_blank'>/wai-aria/table_colcount_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-203-0' class='subtest'><td>table colcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is -1" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -2282,8 +2289,8 @@ ERROR: atspi_error: Get failed (1) <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-200'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_8-manual.html' target='_blank'>/wai-aria/table_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-200-0' class='subtest'><td>table colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-204'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_8-manual.html' target='_blank'>/wai-aria/table_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-204-0' class='subtest'><td>table colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -2296,8 +2303,8 @@ ERROR: atspi_error: Get failed (1) <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-201'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_-1-manual.html' target='_blank'>/wai-aria/table_rowcount_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-201-0' class='subtest'><td>table rowcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-205'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_-1-manual.html' target='_blank'>/wai-aria/table_rowcount_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-205-0' class='subtest'><td>table rowcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is -1" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -2310,8 +2317,8 @@ ERROR: atspi_error: Get failed (1) <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-202'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_3-manual.html' target='_blank'>/wai-aria/table_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-202-0' class='subtest'><td>table rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-206'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_3-manual.html' target='_blank'>/wai-aria/table_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-206-0' class='subtest'><td>table rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -2324,14 +2331,14 @@ ERROR: atspi_error: Get failed (1) <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-203'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_horizontal-manual.html' target='_blank'>/wai-aria/tablist_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-203-0' class='subtest'><td>tablist orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-204'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_unspecified-manual.html' target='_blank'>/wai-aria/tablist_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-204-0' class='subtest'><td>tablist orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-205'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_vertical-manual.html' target='_blank'>/wai-aria/tablist_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-205-0' class='subtest'><td>tablist orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-206'><td><a href='http://www.w3c-test.org/wai-aria/term_role-manual.html' target='_blank'>/wai-aria/term_role-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-206-0' class='subtest'><td>term role</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-207'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_horizontal-manual.html' target='_blank'>/wai-aria/tablist_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-207-0' class='subtest'><td>tablist orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-208'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_unspecified-manual.html' target='_blank'>/wai-aria/tablist_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-208-0' class='subtest'><td>tablist orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-209'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_vertical-manual.html' target='_blank'>/wai-aria/tablist_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-209-0' class='subtest'><td>tablist orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-210'><td><a href='http://www.w3c-test.org/wai-aria/term_role-manual.html' target='_blank'>/wai-aria/term_role-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-210-0' class='subtest'><td>term role</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE<em>DESCRIPTION</em>TERM" failed <br />
 <strong>Actual value:</strong> ROLE_SECTION <br />
 <a href="https://bugzil.la/1358417">https://bugzil.la/1358417</a>: [NEW] ARIA term role should be exposed with ATK_ROLE_DESCRIPTION_TERM <br />
@@ -2341,8 +2348,8 @@ ERROR: atspi_error: Get failed (1) <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 is missing roles that are present in ATK <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-207'><td><a href='http://www.w3c-test.org/wai-aria/textbox_placeholder-manual.html' target='_blank'>/wai-aria/textbox_placeholder-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-207-0' class='subtest'><td>textbox placeholder</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-211'><td><a href='http://www.w3c-test.org/wai-aria/textbox_placeholder-manual.html' target='_blank'>/wai-aria/textbox_placeholder-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-211-0' class='subtest'><td>textbox placeholder</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains placeholder-text:DD/MM/YYYY" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'placeholder:DD/MM/YYYY', 'margin-top:0px', 'xml-roles:textbox', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1303429">https://bugzil.la/1303429</a>: [NEW] expose placeholder object attribute for HTML placeholder <br />
@@ -2353,20 +2360,20 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <strong>Actual value:</strong> text entry area <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-208'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_horizontal-manual.html' target='_blank'>/wai-aria/toolbar_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-208-0' class='subtest'><td>toolbar orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-209'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/toolbar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-209-0' class='subtest'><td>toolbar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-210'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_vertical-manual.html' target='_blank'>/wai-aria/toolbar_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-210-0' class='subtest'><td>toolbar orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-211'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_horizontal-manual.html' target='_blank'>/wai-aria/tree_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-211-0' class='subtest'><td>tree orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-212'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_unspecified-manual.html' target='_blank'>/wai-aria/tree_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-212-0' class='subtest'><td>tree orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-213'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_vertical-manual.html' target='_blank'>/wai-aria/tree_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-213-0' class='subtest'><td>tree orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-214'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_colcount_8-manual.html' target='_blank'>/wai-aria/treegrid_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-214-0' class='subtest'><td>treegrid colcount 8</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-212'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_horizontal-manual.html' target='_blank'>/wai-aria/toolbar_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-212-0' class='subtest'><td>toolbar orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-213'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/toolbar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-213-0' class='subtest'><td>toolbar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-214'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_vertical-manual.html' target='_blank'>/wai-aria/toolbar_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-214-0' class='subtest'><td>toolbar orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-215'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_horizontal-manual.html' target='_blank'>/wai-aria/tree_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-215-0' class='subtest'><td>tree orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-216'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_unspecified-manual.html' target='_blank'>/wai-aria/tree_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-216-0' class='subtest'><td>tree orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-217'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_vertical-manual.html' target='_blank'>/wai-aria/tree_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-217-0' class='subtest'><td>tree orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-218'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_colcount_8-manual.html' target='_blank'>/wai-aria/treegrid_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-218-0' class='subtest'><td>treegrid colcount 8</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -2376,19 +2383,19 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-215'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_horizontal-manual.html' target='_blank'>/wai-aria/treegrid_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-215-0' class='subtest'><td>treegrid orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-216'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_unspecified-manual.html' target='_blank'>/wai-aria/treegrid_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-216-0' class='subtest'><td>treegrid orientation unspecified</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-219'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_horizontal-manual.html' target='_blank'>/wai-aria/treegrid_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-219-0' class='subtest'><td>treegrid orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-220'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_unspecified-manual.html' target='_blank'>/wai-aria/treegrid_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-220-0' class='subtest'><td>treegrid orientation unspecified</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_VERTICAL" failed <br />
 <strong>Actual value:</strong> ['STATE_EDITABLE', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE'] <br />
 <a href="https://bugzil.la/1357042">https://bugzil.la/1357042</a>: [NEW] Implement or update support for exposure of aria-orientation via ATK StateSet <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-217'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_vertical-manual.html' target='_blank'>/wai-aria/treegrid_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-217-0' class='subtest'><td>treegrid orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-218'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_rowcount_3-manual.html' target='_blank'>/wai-aria/treegrid_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-218-0' class='subtest'><td>treegrid rowcount 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-221'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_vertical-manual.html' target='_blank'>/wai-aria/treegrid_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-221-0' class='subtest'><td>treegrid orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-222'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_rowcount_3-manual.html' target='_blank'>/wai-aria/treegrid_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-222-0' class='subtest'><td>treegrid rowcount 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -2398,8 +2405,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-219'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_false-manual.html' target='_blank'>/wai-aria/treeitem_selected_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-219-0' class='subtest'><td>treeitem selected false</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-223'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_false-manual.html' target='_blank'>/wai-aria/treeitem_selected_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-223-0' class='subtest'><td>treeitem selected false</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE<em>TREE</em>ITEM" failed <br />
 <strong>Actual value:</strong> ROLE_LIST_ITEM <br />
 <a href="https://bugzil.la/1355423">https://bugzil.la/1355423</a>: [NEW] ARIA treeitem role should be mapped as ATK_ROLE_TREE_ITEM; not ATK_ROLE_LIST_ITEM <br />
@@ -2408,8 +2415,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <strong>Actual value:</strong> row <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-220'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_true-manual.html' target='_blank'>/wai-aria/treeitem_selected_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-220-0' class='subtest'><td>treeitem selected true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-224'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_true-manual.html' target='_blank'>/wai-aria/treeitem_selected_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-224-0' class='subtest'><td>treeitem selected true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE<em>TREE</em>ITEM" failed <br />
 <strong>Actual value:</strong> ROLE_LIST_ITEM <br />
 <a href="https://bugzil.la/1355423">https://bugzil.la/1355423</a>: [NEW] ARIA treeitem role should be mapped as ATK_ROLE_TREE_ITEM; not ATK_ROLE_LIST_ITEM <br />
@@ -2420,8 +2427,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-221'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_undefined-manual.html' target='_blank'>/wai-aria/treeitem_selected_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-221-0' class='subtest'><td>treeitem selected undefined</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-225'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_undefined-manual.html' target='_blank'>/wai-aria/treeitem_selected_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-225-0' class='subtest'><td>treeitem selected undefined</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE<em>TREE</em>ITEM" failed <br />
 <strong>Actual value:</strong> ROLE_LIST_ITEM <br />
 <a href="https://bugzil.la/1355423">https://bugzil.la/1355423</a>: [NEW] ARIA treeitem role should be mapped as ATK_ROLE_TREE_ITEM; not ATK_ROLE_LIST_ITEM <br />
@@ -2430,8 +2437,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <strong>Actual value:</strong> row <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-222'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_value_changes-manual.html' target='_blank'>/wai-aria/treeitem_selected_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-222-0' class='subtest'><td>treeitem selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-226'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_value_changes-manual.html' target='_blank'>/wai-aria/treeitem_selected_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-226-0' class='subtest'><td>treeitem selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
@@ -2439,13 +2446,13 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-222-1' class='subtest'><td>treeitem selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-226-1' class='subtest'><td>treeitem selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:selection-changed" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-222-2' class='subtest'><td>treeitem selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-226-2' class='subtest'><td>treeitem selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>

--- a/wai-aria/complete-fails.html
+++ b/wai-aria/complete-fails.html
@@ -12,18 +12,16 @@
         <h1>WAI ARIA 1.1: Complete Failures</h1>
       </header>
       
-      <p><strong>Completely failed files</strong>: 40; <strong>Completely failed subtests</strong>: 14; <strong>Failure level</strong>: 14/248 (5.65%)</p>
+      <p><strong>Completely failed files</strong>: 38; <strong>Completely failed subtests</strong>: 12; <strong>Failure level</strong>: 12/252 (4.76%)</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/wai-aria/application_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
 <li><a href='#test-file-1'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-2'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-3'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-4'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-5'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-6'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-7'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-8'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-9'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-2'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-3'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-4'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-5'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-6'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-7'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
@@ -74,7 +72,7 @@
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-13-0' class='subtest'><td>aria-details pointing to details element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
 <strong>Actual value:</strong> [] <br />
@@ -100,7 +98,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details an
 https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-14-0' class='subtest'><td>aria-details pointing to div element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
 <strong>Actual value:</strong> [] <br />
@@ -126,46 +124,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details an
 https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-33-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
-<strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'table-cell-index:0', 'tag:td', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px', 'colspan:2'] <br />
-<a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
-<strong>Actual value:</strong> AXGroup <br />
-; "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> None <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=3" failed <br />
-<strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
-<a href="https://webkit.org/b/171165">https://webkit.org/b/171165</a>: [NEW] [ATK] atk_table_cell_get_row_column_span() should return values of aria-rowspan and aria-colspan, if present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> 1 <br />
-<a href="https://webkit.org/b/171178">https://webkit.org/b/171178</a>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-45-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
-<strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'text-indent:0px', 'text-align:center', 'margin-left:0px', 'colspan:2'] <br />
-<a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> None <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=3" failed <br />
-<strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
-<a href="https://webkit.org/b/171165">https://webkit.org/b/171165</a>: [NEW] [ATK] atk_table_cell_get_row_column_span() should return values of aria-rowspan and aria-colspan, if present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> 1 <br />
-<a href="https://webkit.org/b/171178">https://webkit.org/b/171178</a>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-73'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-73-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-77-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -179,7 +139,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-73-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-77-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -189,8 +149,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-mess
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-74-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-78-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -204,7 +164,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-74-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-78-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -214,8 +174,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-mess
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-156'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-156-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 ; "property states contains STATE_FOCUSABLE" failed <br />
@@ -241,8 +201,8 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-157'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-157-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 ; "property states contains STATE_FOCUSABLE" failed <br />

--- a/wai-aria/consolidated.json
+++ b/wai-aria/consolidated.json
@@ -1149,17 +1149,16 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
-            "WK01": "FAIL",
-            "WK02": "FAIL"
+            "WK01": "PASS",
+            "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property objectAttributes doesNotContain colspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'table-cell-index:0', 'tag:td', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px', 'colspan:2']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false",
-            "WK01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=3\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://webkit.org/b/171165>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should return values of aria-rowspan and aria-colspan, if present  \n;  expected true got false",
-            "WK02": "assert_true: \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171178>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells  \n;  expected true got false"
+            "GC02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4
+            "FAIL": 2,
+            "PASS": 2
           }
         }
       }
@@ -1190,6 +1189,36 @@
           "totals": {
             "FAIL": 1,
             "PASS": 3
+          }
+        }
+      }
+    },
+    "/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html": {
+      "byUA": {
+        "FF01": "OK",
+        "GC02": "OK",
+        "WK01": "OK",
+        "WK02": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 4
+      },
+      "subtests": {
+        "cell aria-colspan 2 on td html colspan 3 with three actual columns": {
+          "stNum": 0,
+          "byUA": {
+            "FF01": "PASS",
+            "GC02": "FAIL",
+            "WK01": "PASS",
+            "WK02": "PASS"
+          },
+          "UAmessage": {
+            "GC02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
+          "totals": {
+            "PASS": 3,
+            "FAIL": 1
           }
         }
       }
@@ -1272,12 +1301,42 @@
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "GC02": "PASS",
+            "WK01": "PASS",
+            "WK02": "PASS"
+          },
+          "UAmessage": {
+            "FF01": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:cell', 'table-cell-index:0', 'tag:td', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false"
+          },
+          "totals": {
+            "FAIL": 1,
+            "PASS": 3
+          }
+        }
+      }
+    },
+    "/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html": {
+      "byUA": {
+        "FF01": "OK",
+        "GC02": "OK",
+        "WK01": "OK",
+        "WK02": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 4
+      },
+      "subtests": {
+        "cell aria-rowspan 2 on td html rowspan 3 with three actual rows": {
+          "stNum": 0,
+          "byUA": {
+            "FF01": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:cell', 'table-cell-index:0', 'tag:td', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n; \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=1, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
@@ -1519,18 +1578,46 @@
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "FAIL",
-            "WK02": "FAIL"
+            "GC02": "PASS",
+            "WK01": "PASS",
+            "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes doesNotContain colspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'text-indent:0px', 'text-align:center', 'margin-left:0px', 'colspan:2']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false",
-            "GC02": "assert_true: \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false",
-            "WK01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=3\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://webkit.org/b/171165>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should return values of aria-rowspan and aria-colspan, if present  \n;  expected true got false",
-            "WK02": "assert_true: \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171178>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property objectAttributes doesNotContain colspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'text-indent:0px', 'text-align:center', 'margin-left:0px', 'colspan:2']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4
+            "FAIL": 1,
+            "PASS": 3
+          }
+        }
+      }
+    },
+    "/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html": {
+      "byUA": {
+        "FF01": "OK",
+        "GC02": "OK",
+        "WK01": "OK",
+        "WK02": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 4
+      },
+      "subtests": {
+        "columnheader aria-colspan 2 on th html colspan 3 with three actual columns": {
+          "stNum": 0,
+          "byUA": {
+            "FF01": "PASS",
+            "GC02": "FAIL",
+            "WK01": "PASS",
+            "WK02": "PASS"
+          },
+          "UAmessage": {
+            "GC02": "assert_true: \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
+          "totals": {
+            "PASS": 3,
+            "FAIL": 1
           }
         }
       }
@@ -1613,12 +1700,42 @@
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "GC02": "PASS",
+            "WK01": "PASS",
+            "WK02": "PASS"
+          },
+          "UAmessage": {
+            "FF01": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:center', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false"
+          },
+          "totals": {
+            "FAIL": 1,
+            "PASS": 3
+          }
+        }
+      }
+    },
+    "/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html": {
+      "byUA": {
+        "FF01": "OK",
+        "GC02": "OK",
+        "WK01": "OK",
+        "WK02": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 4
+      },
+      "subtests": {
+        "columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows": {
+          "stNum": 0,
+          "byUA": {
+            "FF01": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:center', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n; \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=1, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {

--- a/wai-aria/less-than-2.html
+++ b/wai-aria/less-than-2.html
@@ -12,48 +12,46 @@
         <h1>WAI ARIA 1.1: Less Than 2 Passes</h1>
       </header>
       
-      <p><strong>Test files without 2 passes</strong>: 40; <strong>Subtests without 2 passes: </strong>52; <strong>Failure level</strong>: 52/248 (20.97%)</p>
+      <p><strong>Test files without 2 passes</strong>: 38; <strong>Subtests without 2 passes: </strong>50; <strong>Failure level</strong>: 50/252 (19.84%)</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/wai-aria/alertdialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-1'>/wai-aria/application_activedescendant-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-2'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-3'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-4'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
+<li><a href='#test-file-1'>/wai-aria/application_activedescendant-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-2'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-3'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-4'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
 <li><a href='#test-file-5'>/wai-aria/button_haspopup_emptystring-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
 <li><a href='#test-file-6'>/wai-aria/button_haspopup_foo-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-7'>/wai-aria/cell-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-8'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-9'>/wai-aria/cell_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-10'>/wai-aria/cell_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-11'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-12'>/wai-aria/columnheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-13'>/wai-aria/columnheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-14'>/wai-aria/combobox_haspopup_dialog-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-15'>/wai-aria/combobox_haspopup_grid-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-16'>/wai-aria/combobox_haspopup_listbox-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-17'>/wai-aria/combobox_haspopup_menu-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-18'>/wai-aria/combobox_haspopup_tree-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-19'>/wai-aria/combobox_haspopup_true-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-20'>/wai-aria/combobox_haspopup_unspecified-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-21'>/wai-aria/dialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-22'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-23'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-24'>/wai-aria/grid_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-25'>/wai-aria/grid_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-26'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-27'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-28'>/wai-aria/option_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.21% of total)</small></li>
-<li><a href='#test-file-29'>/wai-aria/row_colindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-30'>/wai-aria/row_rowindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-31'>/wai-aria/rowheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-32'>/wai-aria/rowheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-33'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-34'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></li>
-<li><a href='#test-file-35'>/wai-aria/table_colcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-36'>/wai-aria/table_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-37'>/wai-aria/table_rowcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-38'>/wai-aria/table_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-39'>/wai-aria/treeitem_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.21% of total)</small></li>
+<li><a href='#test-file-7'>/wai-aria/cell-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-8'>/wai-aria/cell_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-9'>/wai-aria/cell_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-10'>/wai-aria/columnheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-11'>/wai-aria/columnheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-12'>/wai-aria/combobox_haspopup_dialog-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-13'>/wai-aria/combobox_haspopup_grid-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-14'>/wai-aria/combobox_haspopup_listbox-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-15'>/wai-aria/combobox_haspopup_menu-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-16'>/wai-aria/combobox_haspopup_tree-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-17'>/wai-aria/combobox_haspopup_true-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-18'>/wai-aria/combobox_haspopup_unspecified-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-19'>/wai-aria/dialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-20'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-21'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-22'>/wai-aria/grid_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-23'>/wai-aria/grid_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-24'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-25'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-26'>/wai-aria/option_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></li>
+<li><a href='#test-file-27'>/wai-aria/row_colindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-28'>/wai-aria/row_rowindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-29'>/wai-aria/rowheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-30'>/wai-aria/rowheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-31'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-32'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
+<li><a href='#test-file-33'>/wai-aria/table_colcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-34'>/wai-aria/table_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-35'>/wai-aria/table_rowcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-36'>/wai-aria/table_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-37'>/wai-aria/treeitem_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
@@ -63,7 +61,7 @@
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant-manual.html' target='_blank'>/wai-aria/application_activedescendant-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant-manual.html' target='_blank'>/wai-aria/application_activedescendant-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-2-0' class='subtest'><td>application activedescendant</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
 <strong>Actual value:</strong> AXLandmarkApplication <br />
@@ -98,7 +96,7 @@
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-3-0' class='subtest'><td>application activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
 <strong>Actual value:</strong> AXLandmarkApplication <br />
@@ -138,7 +136,7 @@
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-13-0' class='subtest'><td>aria-details pointing to details element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
 <strong>Actual value:</strong> [] <br />
@@ -164,7 +162,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details an
 https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-14-0' class='subtest'><td>aria-details pointing to div element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
 <strong>Actual value:</strong> [] <br />
@@ -264,7 +262,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/wai-aria/cell-manual.html' target='_blank'>/wai-aria/cell-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/wai-aria/cell-manual.html' target='_blank'>/wai-aria/cell-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-31-0' class='subtest'><td>cell</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
@@ -291,28 +289,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-33-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
-<strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'table-cell-index:0', 'tag:td', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px', 'colspan:2'] <br />
-<a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
-<strong>Actual value:</strong> AXGroup <br />
-; "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> None <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=3" failed <br />
-<strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
-<a href="https://webkit.org/b/171165">https://webkit.org/b/171165</a>: [NEW] [ATK] atk_table_cell_get_row_column_span() should return values of aria-rowspan and aria-colspan, if present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> 1 <br />
-<a href="https://webkit.org/b/171178">https://webkit.org/b/171178</a>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-39'><td><a href='http://www.w3c-test.org/wai-aria/cell_colindex_4-manual.html' target='_blank'>/wai-aria/cell_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-39-0' class='subtest'><td>cell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/wai-aria/cell_colindex_4-manual.html' target='_blank'>/wai-aria/cell_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-41-0' class='subtest'><td>cell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -325,8 +303,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-40'><td><a href='http://www.w3c-test.org/wai-aria/cell_rowindex_4-manual.html' target='_blank'>/wai-aria/cell_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-40-0' class='subtest'><td>cell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/wai-aria/cell_rowindex_4-manual.html' target='_blank'>/wai-aria/cell_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-42-0' class='subtest'><td>cell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -339,26 +317,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-45-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
-<strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'text-indent:0px', 'text-align:center', 'margin-left:0px', 'colspan:2'] <br />
-<a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> None <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=3" failed <br />
-<strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
-<a href="https://webkit.org/b/171165">https://webkit.org/b/171165</a>: [NEW] [ATK] atk_table_cell_get_row_column_span() should return values of aria-rowspan and aria-colspan, if present <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> 1 <br />
-<a href="https://webkit.org/b/171178">https://webkit.org/b/171178</a>: [RESOLVED FIXED] AX: Treat cells with ARIA table cell properties as cells <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-50'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_colindex_4-manual.html' target='_blank'>/wai-aria/columnheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-50-0' class='subtest'><td>columnheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_colindex_4-manual.html' target='_blank'>/wai-aria/columnheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-54-0' class='subtest'><td>columnheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -371,8 +331,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-51'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_rowindex_4-manual.html' target='_blank'>/wai-aria/columnheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-51-0' class='subtest'><td>columnheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_rowindex_4-manual.html' target='_blank'>/wai-aria/columnheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-55-0' class='subtest'><td>columnheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -385,8 +345,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_dialog-manual.html' target='_blank'>/wai-aria/combobox_haspopup_dialog-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-55-0' class='subtest'><td>combobox haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_dialog-manual.html' target='_blank'>/wai-aria/combobox_haspopup_dialog-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-59-0' class='subtest'><td>combobox haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -408,8 +368,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-57'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_grid-manual.html' target='_blank'>/wai-aria/combobox_haspopup_grid-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-57-0' class='subtest'><td>combobox haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-61'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_grid-manual.html' target='_blank'>/wai-aria/combobox_haspopup_grid-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-61-0' class='subtest'><td>combobox haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -431,8 +391,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-58'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_listbox-manual.html' target='_blank'>/wai-aria/combobox_haspopup_listbox-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-58-0' class='subtest'><td>combobox haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_listbox-manual.html' target='_blank'>/wai-aria/combobox_haspopup_listbox-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-62-0' class='subtest'><td>combobox haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -454,8 +414,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_menu-manual.html' target='_blank'>/wai-aria/combobox_haspopup_menu-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-59-0' class='subtest'><td>combobox haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-63'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_menu-manual.html' target='_blank'>/wai-aria/combobox_haspopup_menu-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-63-0' class='subtest'><td>combobox haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -477,8 +437,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-60'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_tree-manual.html' target='_blank'>/wai-aria/combobox_haspopup_tree-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-60-0' class='subtest'><td>combobox haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-64'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_tree-manual.html' target='_blank'>/wai-aria/combobox_haspopup_tree-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-64-0' class='subtest'><td>combobox haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -500,8 +460,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-61'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_true-manual.html' target='_blank'>/wai-aria/combobox_haspopup_true-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-61-0' class='subtest'><td>combobox haspopup true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-65'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_true-manual.html' target='_blank'>/wai-aria/combobox_haspopup_true-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-65-0' class='subtest'><td>combobox haspopup true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -520,8 +480,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/combobox_haspopup_unspecified-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-62-0' class='subtest'><td>combobox haspopup unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-66'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/combobox_haspopup_unspecified-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-66-0' class='subtest'><td>combobox haspopup unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
@@ -543,14 +503,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-70'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_true-manual.html' target='_blank'>/wai-aria/dialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-70-1' class='subtest'><td>dialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_true-manual.html' target='_blank'>/wai-aria/dialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-74-1' class='subtest'><td>dialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-73'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-73-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-77-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -564,7 +524,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-73-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-77-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -574,8 +534,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-mess
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-74-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-78-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -589,7 +549,7 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-74-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-78-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
 <strong>Actual value:</strong> [] <br />
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
@@ -599,8 +559,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-mess
 https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-82'><td><a href='http://www.w3c-test.org/wai-aria/grid_colcount_8-manual.html' target='_blank'>/wai-aria/grid_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-82-0' class='subtest'><td>grid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/wai-aria/grid_colcount_8-manual.html' target='_blank'>/wai-aria/grid_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-86-0' class='subtest'><td>grid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -613,8 +573,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-89'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowcount_3-manual.html' target='_blank'>/wai-aria/grid_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-89-0' class='subtest'><td>grid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-93'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowcount_3-manual.html' target='_blank'>/wai-aria/grid_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-93-0' class='subtest'><td>grid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -627,8 +587,8 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-103'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_multiple_shortcuts-manual.html' target='_blank'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-103-0' class='subtest'><td>keyshortcuts multiple shortcuts</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-107'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_multiple_shortcuts-manual.html' target='_blank'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-107-0' class='subtest'><td>keyshortcuts multiple shortcuts</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
@@ -645,8 +605,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/159215">https://webkit.org/b/159215</a>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-104'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_one_shortcut-manual.html' target='_blank'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-104-0' class='subtest'><td>keyshortcuts one shortcut</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-108'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_one_shortcut-manual.html' target='_blank'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-108-0' class='subtest'><td>keyshortcuts one shortcut</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
@@ -663,8 +623,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/159215">https://webkit.org/b/159215</a>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_value_changes-manual.html' target='_blank'>/wai-aria/option_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.21% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-135-0' class='subtest'><td>option selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-139'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_value_changes-manual.html' target='_blank'>/wai-aria/option_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-139-0' class='subtest'><td>option selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
@@ -672,18 +632,18 @@ ERROR: 'NoneType' object is not callable <br />
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-135-1' class='subtest'><td>option selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-139-1' class='subtest'><td>option selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:selection-changed" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-135-2' class='subtest'><td>option selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-139-2' class='subtest'><td>option selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-144'><td><a href='http://www.w3c-test.org/wai-aria/row_colindex_4-manual.html' target='_blank'>/wai-aria/row_colindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-144-1' class='subtest'><td>row colindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-148'><td><a href='http://www.w3c-test.org/wai-aria/row_colindex_4-manual.html' target='_blank'>/wai-aria/row_colindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-148-1' class='subtest'><td>row colindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -696,8 +656,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-145'><td><a href='http://www.w3c-test.org/wai-aria/row_rowindex_4-manual.html' target='_blank'>/wai-aria/row_rowindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-145-1' class='subtest'><td>row rowindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-149'><td><a href='http://www.w3c-test.org/wai-aria/row_rowindex_4-manual.html' target='_blank'>/wai-aria/row_rowindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-149-1' class='subtest'><td>row rowindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -710,8 +670,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-148'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_colindex_4-manual.html' target='_blank'>/wai-aria/rowheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-148-0' class='subtest'><td>rowheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-152'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_colindex_4-manual.html' target='_blank'>/wai-aria/rowheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-152-0' class='subtest'><td>rowheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -724,8 +684,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-149'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_rowindex_4-manual.html' target='_blank'>/wai-aria/rowheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-149-0' class='subtest'><td>rowheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-153'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_rowindex_4-manual.html' target='_blank'>/wai-aria/rowheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-153-0' class='subtest'><td>rowheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
@@ -738,8 +698,8 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-156'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-156-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 ; "property states contains STATE_FOCUSABLE" failed <br />
@@ -765,8 +725,8 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-157'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-157-0' class='subtest'><td>searchbox activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-161-0' class='subtest'><td>searchbox activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result array isNot true" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states doesNotContain STATE_FOCUSED" failed <br />
@@ -777,7 +737,7 @@ ERROR: Object not found <br />
 ; "result array isNot true" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-157-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 ; "property states contains STATE_FOCUSABLE" failed <br />
@@ -803,8 +763,8 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-199'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_-1-manual.html' target='_blank'>/wai-aria/table_colcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-199-0' class='subtest'><td>table colcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-203'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_-1-manual.html' target='_blank'>/wai-aria/table_colcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-203-0' class='subtest'><td>table colcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is -1" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -817,8 +777,8 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-200'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_8-manual.html' target='_blank'>/wai-aria/table_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-200-0' class='subtest'><td>table colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-204'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_8-manual.html' target='_blank'>/wai-aria/table_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-204-0' class='subtest'><td>table colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -831,8 +791,8 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-201'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_-1-manual.html' target='_blank'>/wai-aria/table_rowcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-201-0' class='subtest'><td>table rowcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-205'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_-1-manual.html' target='_blank'>/wai-aria/table_rowcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-205-0' class='subtest'><td>table rowcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is -1" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -845,8 +805,8 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-202'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_3-manual.html' target='_blank'>/wai-aria/table_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-202-0' class='subtest'><td>table rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-206'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_3-manual.html' target='_blank'>/wai-aria/table_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-206-0' class='subtest'><td>table rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
@@ -859,8 +819,8 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-222'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_value_changes-manual.html' target='_blank'>/wai-aria/treeitem_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.21% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-222-0' class='subtest'><td>treeitem selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-226'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_value_changes-manual.html' target='_blank'>/wai-aria/treeitem_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-226-0' class='subtest'><td>treeitem selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
@@ -868,13 +828,13 @@ ERROR: Object not found <br />
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-222-1' class='subtest'><td>treeitem selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-226-1' class='subtest'><td>treeitem selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:selection-changed" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-222-2' class='subtest'><td>treeitem selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr id='subtest-226-2' class='subtest'><td>treeitem selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>


### PR DESCRIPTION
Several of the tests related to aria-rowspan and aria-colspan had to be
modified and several additional tests written so that we can test that
the native host-language property's value is used if present. This commit
updates the results for those tests.