### PR TITLE
DPub-AAM: Updated results

### DIFF
--- a/dpub-aam/ME05.json
+++ b/dpub-aam/ME05.json
@@ -5,8 +5,8 @@
       "subtests": [
         {
           "name": "doc-abstract",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -17,8 +17,8 @@
       "subtests": [
         {
           "name": "doc-acknowledgments",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -29,8 +29,8 @@
       "subtests": [
         {
           "name": "doc-afterword",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -41,8 +41,8 @@
       "subtests": [
         {
           "name": "doc-appendix",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -53,8 +53,8 @@
       "subtests": [
         {
           "name": "doc-backlink",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -65,8 +65,8 @@
       "subtests": [
         {
           "name": "doc-biblioentry",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -77,8 +77,8 @@
       "subtests": [
         {
           "name": "doc-bibliography",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -89,8 +89,8 @@
       "subtests": [
         {
           "name": "doc-biblioref",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -101,8 +101,8 @@
       "subtests": [
         {
           "name": "doc-chapter",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -113,8 +113,8 @@
       "subtests": [
         {
           "name": "doc-colophon",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -125,8 +125,8 @@
       "subtests": [
         {
           "name": "doc-conclusion",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -137,8 +137,8 @@
       "subtests": [
         {
           "name": "doc-cover",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -149,8 +149,8 @@
       "subtests": [
         {
           "name": "doc-credit",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -161,8 +161,8 @@
       "subtests": [
         {
           "name": "doc-credits",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -173,8 +173,8 @@
       "subtests": [
         {
           "name": "doc-dedication",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -185,8 +185,8 @@
       "subtests": [
         {
           "name": "doc-endnote",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -197,8 +197,8 @@
       "subtests": [
         {
           "name": "doc-endnotes",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -209,8 +209,8 @@
       "subtests": [
         {
           "name": "doc-epigraph",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -221,8 +221,8 @@
       "subtests": [
         {
           "name": "doc-epilogue",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -233,8 +233,8 @@
       "subtests": [
         {
           "name": "doc-errata",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -245,8 +245,8 @@
       "subtests": [
         {
           "name": "doc-example",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -257,8 +257,8 @@
       "subtests": [
         {
           "name": "doc-footnote",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -269,8 +269,8 @@
       "subtests": [
         {
           "name": "doc-foreword",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -281,8 +281,8 @@
       "subtests": [
         {
           "name": "doc-glossary",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -293,8 +293,8 @@
       "subtests": [
         {
           "name": "doc-glossref",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -305,8 +305,8 @@
       "subtests": [
         {
           "name": "doc-index",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -317,8 +317,8 @@
       "subtests": [
         {
           "name": "doc-introduction",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -329,8 +329,8 @@
       "subtests": [
         {
           "name": "doc-noteref",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -341,8 +341,8 @@
       "subtests": [
         {
           "name": "doc-notice",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -353,8 +353,8 @@
       "subtests": [
         {
           "name": "doc-pagebreak",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -365,8 +365,8 @@
       "subtests": [
         {
           "name": "doc-pagelist",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -377,8 +377,8 @@
       "subtests": [
         {
           "name": "doc-part",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -389,8 +389,8 @@
       "subtests": [
         {
           "name": "doc-preface",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -401,8 +401,8 @@
       "subtests": [
         {
           "name": "doc-prologue",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -413,8 +413,8 @@
       "subtests": [
         {
           "name": "doc-pullquote",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -425,8 +425,8 @@
       "subtests": [
         {
           "name": "doc-qna",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -437,8 +437,8 @@
       "subtests": [
         {
           "name": "doc-subtitle",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -449,8 +449,8 @@
       "subtests": [
         {
           "name": "doc-tip",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",
@@ -461,8 +461,8 @@
       "subtests": [
         {
           "name": "doc-toc",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
         }
       ],
       "status": "OK",

--- a/dpub-aam/README.md
+++ b/dpub-aam/README.md
@@ -5,9 +5,9 @@ This document is a place holder until test results are available.
 
 Up-to-date result reports are available at:
 
-* https://w3c.github.io/test-results/dpub-aam/all.html
-* https://w3c.github.io/test-results/dpub-aam/less-than-2.html
-* https://w3c.github.io/test-results/dpub-aam/complete-fails.html
+* <https://w3c.github.io/test-results/dpub-aam/all.html>
+* <https://w3c.github.io/test-results/dpub-aam/less-than-2.html>
+* <https://w3c.github.io/test-results/dpub-aam/complete-fails.html>
 
 List of supported AT APIs
 =========================
@@ -26,19 +26,23 @@ Index of implementations in reports
 
 * FF01 - Firefox on Linux using ATK
   * email: jdiggs@igalia.com
-  * link: http://www.mozilla.org
+  * link: <http://www.mozilla.org>
 
 * WK01 - WebKit on Linux using ATK
   * email: jdiggs@igalia.com
-  * link: https://webkitgtk.org
+  * link: <https://webkitgtk.org>
 
 * WK02 - WebKit on OS X using AXAPI
   * email: jdiggs@igalia.com
-  * link: https://webkit.org
+  * link: <https://webkit.org>
 
 * GC02 - Chrome on OS X using AXAPI
   * email: jdiggs@igalia.com
-  * link: https://www.google.com/chrome/
+  * link: <https://www.google.com/chrome/>
+
+* ME05 - Microsoft Edge using UIA
+  * email: bbrinza@microsoft.com
+  * link: <https://www.microsoft.com/microsoft-edge>
 
 Adding new results
 ==================

--- a/dpub-aam/all.html
+++ b/dpub-aam/all.html
@@ -55,194 +55,232 @@
 <li><a href='#test-file-38'>/dpub-aam/doc-toc-manual.html</a></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/dpub-aam/doc-abstract-manual.html' target='_blank'>/dpub-aam/doc-abstract-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-0-0' class='subtest'><td>doc-abstract</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/dpub-aam/doc-abstract-manual.html' target='_blank'>/dpub-aam/doc-abstract-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-0-0' class='subtest'><td>doc-abstract</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/dpub-aam/doc-acknowledgments-manual.html' target='_blank'>/dpub-aam/doc-acknowledgments-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-1-0' class='subtest'><td>doc-acknowledgments</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/dpub-aam/doc-acknowledgments-manual.html' target='_blank'>/dpub-aam/doc-acknowledgments-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-1-0' class='subtest'><td>doc-acknowledgments</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/dpub-aam/doc-afterword-manual.html' target='_blank'>/dpub-aam/doc-afterword-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-2-0' class='subtest'><td>doc-afterword</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/dpub-aam/doc-afterword-manual.html' target='_blank'>/dpub-aam/doc-afterword-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-2-0' class='subtest'><td>doc-afterword</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/dpub-aam/doc-appendix-manual.html' target='_blank'>/dpub-aam/doc-appendix-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-3-0' class='subtest'><td>doc-appendix</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/dpub-aam/doc-appendix-manual.html' target='_blank'>/dpub-aam/doc-appendix-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-3-0' class='subtest'><td>doc-appendix</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/dpub-aam/doc-backlink-manual.html' target='_blank'>/dpub-aam/doc-backlink-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-4-0' class='subtest'><td>doc-backlink</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/dpub-aam/doc-backlink-manual.html' target='_blank'>/dpub-aam/doc-backlink-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-4-0' class='subtest'><td>doc-backlink</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed ; "property AXRoleDescription is link" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/dpub-aam/doc-biblioentry-manual.html' target='_blank'>/dpub-aam/doc-biblioentry-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-5-0' class='subtest'><td>doc-biblioentry</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LIST_ITEM" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/dpub-aam/doc-biblioentry-manual.html' target='_blank'>/dpub-aam/doc-biblioentry-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-5-0' class='subtest'><td>doc-biblioentry</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LIST_ITEM" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/dpub-aam/doc-bibliography-manual.html' target='_blank'>/dpub-aam/doc-bibliography-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-6-0' class='subtest'><td>doc-bibliography</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/dpub-aam/doc-bibliography-manual.html' target='_blank'>/dpub-aam/doc-bibliography-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-6-0' class='subtest'><td>doc-bibliography</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/dpub-aam/doc-biblioref-manual.html' target='_blank'>/dpub-aam/doc-biblioref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-7-0' class='subtest'><td>doc-biblioref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/dpub-aam/doc-biblioref-manual.html' target='_blank'>/dpub-aam/doc-biblioref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-7-0' class='subtest'><td>doc-biblioref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed ; "property AXRoleDescription is link" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/dpub-aam/doc-chapter-manual.html' target='_blank'>/dpub-aam/doc-chapter-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-8-0' class='subtest'><td>doc-chapter</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/dpub-aam/doc-chapter-manual.html' target='_blank'>/dpub-aam/doc-chapter-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-8-0' class='subtest'><td>doc-chapter</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/dpub-aam/doc-colophon-manual.html' target='_blank'>/dpub-aam/doc-colophon-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-9-0' class='subtest'><td>doc-colophon</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/dpub-aam/doc-colophon-manual.html' target='_blank'>/dpub-aam/doc-colophon-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-9-0' class='subtest'><td>doc-colophon</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/dpub-aam/doc-conclusion-manual.html' target='_blank'>/dpub-aam/doc-conclusion-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-10-0' class='subtest'><td>doc-conclusion</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/dpub-aam/doc-conclusion-manual.html' target='_blank'>/dpub-aam/doc-conclusion-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-10-0' class='subtest'><td>doc-conclusion</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/dpub-aam/doc-cover-manual.html' target='_blank'>/dpub-aam/doc-cover-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-11-0' class='subtest'><td>doc-cover</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>IMAGE" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/dpub-aam/doc-cover-manual.html' target='_blank'>/dpub-aam/doc-cover-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-11-0' class='subtest'><td>doc-cover</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>IMAGE" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXImage" failed ; "property AXRoleDescription is image" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/dpub-aam/doc-credit-manual.html' target='_blank'>/dpub-aam/doc-credit-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-12-0' class='subtest'><td>doc-credit</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/dpub-aam/doc-credit-manual.html' target='_blank'>/dpub-aam/doc-credit-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-12-0' class='subtest'><td>doc-credit</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/dpub-aam/doc-credits-manual.html' target='_blank'>/dpub-aam/doc-credits-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-13-0' class='subtest'><td>doc-credits</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/dpub-aam/doc-credits-manual.html' target='_blank'>/dpub-aam/doc-credits-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-13-0' class='subtest'><td>doc-credits</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/dpub-aam/doc-dedication-manual.html' target='_blank'>/dpub-aam/doc-dedication-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-14-0' class='subtest'><td>doc-dedication</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/dpub-aam/doc-dedication-manual.html' target='_blank'>/dpub-aam/doc-dedication-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-14-0' class='subtest'><td>doc-dedication</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/dpub-aam/doc-endnote-manual.html' target='_blank'>/dpub-aam/doc-endnote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-15-0' class='subtest'><td>doc-endnote</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LIST_ITEM" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/dpub-aam/doc-endnote-manual.html' target='_blank'>/dpub-aam/doc-endnote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-15-0' class='subtest'><td>doc-endnote</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LIST_ITEM" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/dpub-aam/doc-endnotes-manual.html' target='_blank'>/dpub-aam/doc-endnotes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-16-0' class='subtest'><td>doc-endnotes</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/dpub-aam/doc-endnotes-manual.html' target='_blank'>/dpub-aam/doc-endnotes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-16-0' class='subtest'><td>doc-endnotes</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/dpub-aam/doc-epigraph-manual.html' target='_blank'>/dpub-aam/doc-epigraph-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-17-0' class='subtest'><td>doc-epigraph</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/dpub-aam/doc-epigraph-manual.html' target='_blank'>/dpub-aam/doc-epigraph-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-17-0' class='subtest'><td>doc-epigraph</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/dpub-aam/doc-epilogue-manual.html' target='_blank'>/dpub-aam/doc-epilogue-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-18-0' class='subtest'><td>doc-epilogue</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/dpub-aam/doc-epilogue-manual.html' target='_blank'>/dpub-aam/doc-epilogue-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-18-0' class='subtest'><td>doc-epilogue</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/dpub-aam/doc-errata-manual.html' target='_blank'>/dpub-aam/doc-errata-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-19-0' class='subtest'><td>doc-errata</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/dpub-aam/doc-errata-manual.html' target='_blank'>/dpub-aam/doc-errata-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-19-0' class='subtest'><td>doc-errata</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/dpub-aam/doc-example-manual.html' target='_blank'>/dpub-aam/doc-example-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-20-0' class='subtest'><td>doc-example</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/dpub-aam/doc-example-manual.html' target='_blank'>/dpub-aam/doc-example-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-20-0' class='subtest'><td>doc-example</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/dpub-aam/doc-footnote-manual.html' target='_blank'>/dpub-aam/doc-footnote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-21-0' class='subtest'><td>doc-footnote</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>FOOTNOTE" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a "footnote" role;  expected true got false</td></tr>
+<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/dpub-aam/doc-footnote-manual.html' target='_blank'>/dpub-aam/doc-footnote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-21-0' class='subtest'><td>doc-footnote</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>FOOTNOTE" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a "footnote" role;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "property role is ROLE</em>FOOTNOTE" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a "footnote" role;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-22'><td><a href='http://www.w3c-test.org/dpub-aam/doc-foreword-manual.html' target='_blank'>/dpub-aam/doc-foreword-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-22-0' class='subtest'><td>doc-foreword</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-22'><td><a href='http://www.w3c-test.org/dpub-aam/doc-foreword-manual.html' target='_blank'>/dpub-aam/doc-foreword-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-22-0' class='subtest'><td>doc-foreword</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/dpub-aam/doc-glossary-manual.html' target='_blank'>/dpub-aam/doc-glossary-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-23-0' class='subtest'><td>doc-glossary</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/dpub-aam/doc-glossary-manual.html' target='_blank'>/dpub-aam/doc-glossary-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-23-0' class='subtest'><td>doc-glossary</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/dpub-aam/doc-glossref-manual.html' target='_blank'>/dpub-aam/doc-glossref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-24-0' class='subtest'><td>doc-glossref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/dpub-aam/doc-glossref-manual.html' target='_blank'>/dpub-aam/doc-glossref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-24-0' class='subtest'><td>doc-glossref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed ; "property AXRoleDescription is link" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/dpub-aam/doc-index-manual.html' target='_blank'>/dpub-aam/doc-index-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-25-0' class='subtest'><td>doc-index</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/dpub-aam/doc-index-manual.html' target='_blank'>/dpub-aam/doc-index-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-25-0' class='subtest'><td>doc-index</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed ; "property AXRoleDescription is navigation" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-26'><td><a href='http://www.w3c-test.org/dpub-aam/doc-introduction-manual.html' target='_blank'>/dpub-aam/doc-introduction-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-26-0' class='subtest'><td>doc-introduction</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-26'><td><a href='http://www.w3c-test.org/dpub-aam/doc-introduction-manual.html' target='_blank'>/dpub-aam/doc-introduction-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-26-0' class='subtest'><td>doc-introduction</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/dpub-aam/doc-noteref-manual.html' target='_blank'>/dpub-aam/doc-noteref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-27-0' class='subtest'><td>doc-noteref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/dpub-aam/doc-noteref-manual.html' target='_blank'>/dpub-aam/doc-noteref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-27-0' class='subtest'><td>doc-noteref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed ; "property AXRoleDescription is link" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/dpub-aam/doc-notice-manual.html' target='_blank'>/dpub-aam/doc-notice-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-28-0' class='subtest'><td>doc-notice</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>COMMENT" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/dpub-aam/doc-notice-manual.html' target='_blank'>/dpub-aam/doc-notice-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-28-0' class='subtest'><td>doc-notice</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>COMMENT" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXDocumentNote" failed ; "property AXRoleDescription is note" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-29'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pagebreak-manual.html' target='_blank'>/dpub-aam/doc-pagebreak-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-29-0' class='subtest'><td>doc-pagebreak</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>SEPARATOR" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-29'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pagebreak-manual.html' target='_blank'>/dpub-aam/doc-pagebreak-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-29-0' class='subtest'><td>doc-pagebreak</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>SEPARATOR" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXSplitter" failed ; "property AXRoleDescription is splitter" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-30'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pagelist-manual.html' target='_blank'>/dpub-aam/doc-pagelist-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-30-0' class='subtest'><td>doc-pagelist</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-30'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pagelist-manual.html' target='_blank'>/dpub-aam/doc-pagelist-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-30-0' class='subtest'><td>doc-pagelist</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed ; "property AXRoleDescription is navigation" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/dpub-aam/doc-part-manual.html' target='_blank'>/dpub-aam/doc-part-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-31-0' class='subtest'><td>doc-part</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/dpub-aam/doc-part-manual.html' target='_blank'>/dpub-aam/doc-part-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-31-0' class='subtest'><td>doc-part</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-32'><td><a href='http://www.w3c-test.org/dpub-aam/doc-preface-manual.html' target='_blank'>/dpub-aam/doc-preface-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-32-0' class='subtest'><td>doc-preface</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-32'><td><a href='http://www.w3c-test.org/dpub-aam/doc-preface-manual.html' target='_blank'>/dpub-aam/doc-preface-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-32-0' class='subtest'><td>doc-preface</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/dpub-aam/doc-prologue-manual.html' target='_blank'>/dpub-aam/doc-prologue-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-33-0' class='subtest'><td>doc-prologue</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/dpub-aam/doc-prologue-manual.html' target='_blank'>/dpub-aam/doc-prologue-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-33-0' class='subtest'><td>doc-prologue</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pullquote-manual.html' target='_blank'>/dpub-aam/doc-pullquote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-34-0' class='subtest'><td>doc-pullquote</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pullquote-manual.html' target='_blank'>/dpub-aam/doc-pullquote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-34-0' class='subtest'><td>doc-pullquote</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/dpub-aam/doc-qna-manual.html' target='_blank'>/dpub-aam/doc-qna-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-35-0' class='subtest'><td>doc-qna</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/dpub-aam/doc-qna-manual.html' target='_blank'>/dpub-aam/doc-qna-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-35-0' class='subtest'><td>doc-qna</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/dpub-aam/doc-subtitle-manual.html' target='_blank'>/dpub-aam/doc-subtitle-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-36-0' class='subtest'><td>doc-subtitle</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>HEADING" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/dpub-aam/doc-subtitle-manual.html' target='_blank'>/dpub-aam/doc-subtitle-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-36-0' class='subtest'><td>doc-subtitle</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>HEADING" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXHeading" failed ; "property AXRoleDescription is heading" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/dpub-aam/doc-tip-manual.html' target='_blank'>/dpub-aam/doc-tip-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-37-0' class='subtest'><td>doc-tip</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>COMMENT" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/dpub-aam/doc-tip-manual.html' target='_blank'>/dpub-aam/doc-tip-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-37-0' class='subtest'><td>doc-tip</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>COMMENT" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXDocumentNote" failed ; "property AXRoleDescription is note" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/dpub-aam/doc-toc-manual.html' target='_blank'>/dpub-aam/doc-toc-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-38-0' class='subtest'><td>doc-toc</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/dpub-aam/doc-toc-manual.html' target='_blank'>/dpub-aam/doc-toc-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-38-0' class='subtest'><td>doc-toc</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed ; "property AXRoleDescription is navigation" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
 
       </table>

--- a/dpub-aam/complete-fails.html
+++ b/dpub-aam/complete-fails.html
@@ -12,11 +12,11 @@
         <h1>DPUB AAM 1.0: Complete Failures</h1>
       </header>
       
-      <p><strong>Completely failed files</strong>: 1; <strong>Completely failed subtests</strong>: 0; <strong>Failure level</strong>: 0/39 (0.00%)</p>
+      <p><strong>Completely failed files</strong>: 0; <strong>Completely failed subtests</strong>: 0; <strong>Failure level</strong>: 0/39 (0.00%)</p>
       <h3>Test Files</h3>
 <ol class='toc'></ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
 
       </table>
     </div>

--- a/dpub-aam/consolidated.json
+++ b/dpub-aam/consolidated.json
@@ -2,6 +2,7 @@
   "ua": [
     "FF01",
     "GC02",
+    "ME05",
     "WK01",
     "WK02"
   ],
@@ -10,12 +11,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-abstract": {
@@ -23,15 +25,17 @@
           "byUA": {
             "FF01": "PASS",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -40,12 +44,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-acknowledgments": {
@@ -53,15 +58,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -71,12 +78,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-afterword": {
@@ -84,15 +92,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -102,12 +112,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-appendix": {
@@ -115,15 +126,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -133,12 +146,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-backlink": {
@@ -146,15 +160,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -164,12 +180,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-biblioentry": {
@@ -177,15 +194,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LIST_ITEM\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -195,12 +214,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-bibliography": {
@@ -208,15 +228,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -226,12 +248,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-biblioref": {
@@ -239,15 +262,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -257,12 +282,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-chapter": {
@@ -270,15 +296,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -288,12 +316,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-colophon": {
@@ -301,15 +330,17 @@
           "byUA": {
             "FF01": "PASS",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -318,12 +349,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-conclusion": {
@@ -331,15 +363,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -349,12 +383,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-cover": {
@@ -362,15 +397,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_IMAGE\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXImage\" failed ; \"property AXRoleDescription is image\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRole is AXImage\" failed ; \"property AXRoleDescription is image\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -380,12 +417,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-credit": {
@@ -393,15 +431,17 @@
           "byUA": {
             "FF01": "PASS",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -410,12 +450,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-credits": {
@@ -423,15 +464,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -441,12 +484,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-dedication": {
@@ -454,15 +498,17 @@
           "byUA": {
             "FF01": "PASS",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -471,12 +517,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-endnote": {
@@ -484,15 +531,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LIST_ITEM\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -502,12 +551,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-endnotes": {
@@ -515,15 +565,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -533,12 +585,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-epigraph": {
@@ -546,15 +599,17 @@
           "byUA": {
             "FF01": "PASS",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -563,12 +618,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-epilogue": {
@@ -576,15 +632,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -594,12 +652,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-errata": {
@@ -607,15 +666,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -625,12 +686,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-example": {
@@ -638,15 +700,17 @@
           "byUA": {
             "FF01": "PASS",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -655,12 +719,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-footnote": {
@@ -668,17 +733,18 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
-            "WK01": "FAIL",
+            "ME05": "FAIL",
+            "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_FOOTNOTE\" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a \"footnote\" role;  expected true got false",
             "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
-            "WK01": "assert_true: \"property role is ROLE_FOOTNOTE\" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a \"footnote\" role;  expected true got false"
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "FAIL": 3,
-            "PASS": 1
+            "PASS": 2
           }
         }
       }
@@ -687,12 +753,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-foreword": {
@@ -700,15 +767,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -718,12 +787,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-glossary": {
@@ -731,15 +801,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -749,12 +821,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-glossref": {
@@ -762,15 +835,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -780,12 +855,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-index": {
@@ -793,15 +869,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -811,12 +889,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-introduction": {
@@ -824,15 +903,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -842,12 +923,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-noteref": {
@@ -855,15 +937,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -873,12 +957,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-notice": {
@@ -886,15 +971,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_COMMENT\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXDocumentNote\" failed ; \"property AXRoleDescription is note\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXDocumentNote\" failed ; \"property AXRoleDescription is note\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -904,12 +991,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-pagebreak": {
@@ -917,15 +1005,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_SEPARATOR\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXSplitter\" failed ; \"property AXRoleDescription is splitter\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRole is AXSplitter\" failed ; \"property AXRoleDescription is splitter\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -935,12 +1025,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-pagelist": {
@@ -948,15 +1039,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -966,12 +1059,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-part": {
@@ -979,15 +1073,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -997,12 +1093,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-preface": {
@@ -1010,15 +1107,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1028,12 +1127,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-prologue": {
@@ -1041,15 +1141,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1059,12 +1161,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-pullquote": {
@@ -1072,15 +1175,17 @@
           "byUA": {
             "FF01": "PASS",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -1089,12 +1194,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-qna": {
@@ -1102,15 +1208,17 @@
           "byUA": {
             "FF01": "PASS",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -1119,12 +1227,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-subtitle": {
@@ -1132,15 +1241,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_HEADING\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXHeading\" failed ; \"property AXRoleDescription is heading\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXRole is AXHeading\" failed ; \"property AXRoleDescription is heading\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1150,12 +1261,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-tip": {
@@ -1163,15 +1275,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_COMMENT\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXDocumentNote\" failed ; \"property AXRoleDescription is note\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXDocumentNote\" failed ; \"property AXRoleDescription is note\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1181,12 +1295,13 @@
       "byUA": {
         "FF01": "OK",
         "GC02": "OK",
+        "ME05": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "doc-toc": {
@@ -1194,15 +1309,17 @@
           "byUA": {
             "FF01": "FAIL",
             "GC02": "FAIL",
+            "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false"
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false",
+            "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }

--- a/dpub-aam/less-than-2.html
+++ b/dpub-aam/less-than-2.html
@@ -12,18 +12,11 @@
         <h1>DPUB AAM 1.0: Less Than 2 Passes</h1>
       </header>
       
-      <p><strong>Test files without 2 passes</strong>: 1; <strong>Subtests without 2 passes: </strong>1; <strong>Failure level</strong>: 1/39 (2.56%)</p>
+      <p><strong>Test files without 2 passes</strong>: 0; <strong>Subtests without 2 passes: </strong>0; <strong>Failure level</strong>: 0/39 (0.00%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/dpub-aam/doc-footnote-manual.html</a> <small>(1/1, 100.00%, 2.56% of total)</small></li>
-</ol>
+<ol class='toc'></ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
-<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/dpub-aam/doc-footnote-manual.html' target='_blank'>/dpub-aam/doc-footnote-manual.html</a> <small>(1/1, 100.00%, 2.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-21-0' class='subtest'><td>doc-footnote</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>FOOTNOTE" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a "footnote" role;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "property role is ROLE</em>FOOTNOTE" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a "footnote" role;  expected true got false</td></tr>
-</table></td></tr>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
 
       </table>
     </div>


### PR DESCRIPTION
* doc-footnote now passes for WebKitGtk:
  https://trac.webkit.org/changeset/217426

* Add Edge results (all failures) as per:
  https://lists.w3.org/Archives/Public/public-aria/2017May/0081.html

* Make URLs in README.md links