### PR TITLE
DPUB-AAM: New and updated results

### DIFF
--- a/dpub-aam/FF01.json
+++ b/dpub-aam/FF01.json
@@ -17,8 +17,8 @@
       "subtests": [
         {
           "name": "doc-acknowledgments",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -29,8 +29,8 @@
       "subtests": [
         {
           "name": "doc-afterword",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -41,8 +41,8 @@
       "subtests": [
         {
           "name": "doc-appendix",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -53,8 +53,13 @@
       "subtests": [
         {
           "name": "doc-backlink",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "doc-backlink 1",
           "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -65,8 +70,8 @@
       "subtests": [
         {
           "name": "doc-biblioentry",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LIST_ITEM\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -77,8 +82,8 @@
       "subtests": [
         {
           "name": "doc-bibliography",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -89,8 +94,13 @@
       "subtests": [
         {
           "name": "doc-biblioref",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "doc-biblioref 1",
           "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -101,8 +111,8 @@
       "subtests": [
         {
           "name": "doc-chapter",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -125,8 +135,8 @@
       "subtests": [
         {
           "name": "doc-conclusion",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -137,8 +147,8 @@
       "subtests": [
         {
           "name": "doc-cover",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_IMAGE\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -161,8 +171,8 @@
       "subtests": [
         {
           "name": "doc-credits",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -185,8 +195,8 @@
       "subtests": [
         {
           "name": "doc-endnote",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LIST_ITEM\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -197,8 +207,8 @@
       "subtests": [
         {
           "name": "doc-endnotes",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -221,8 +231,8 @@
       "subtests": [
         {
           "name": "doc-epilogue",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -233,8 +243,8 @@
       "subtests": [
         {
           "name": "doc-errata",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -257,8 +267,8 @@
       "subtests": [
         {
           "name": "doc-footnote",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_FOOTNOTE\" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a \"footnote\" role;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -269,8 +279,8 @@
       "subtests": [
         {
           "name": "doc-foreword",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -281,8 +291,8 @@
       "subtests": [
         {
           "name": "doc-glossary",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -293,8 +303,13 @@
       "subtests": [
         {
           "name": "doc-glossref",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "doc-glossref 1",
           "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -305,8 +320,8 @@
       "subtests": [
         {
           "name": "doc-index",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -317,8 +332,8 @@
       "subtests": [
         {
           "name": "doc-introduction",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -329,8 +344,13 @@
       "subtests": [
         {
           "name": "doc-noteref",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "doc-noteref 1",
           "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -341,8 +361,8 @@
       "subtests": [
         {
           "name": "doc-notice",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_COMMENT\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -353,8 +373,8 @@
       "subtests": [
         {
           "name": "doc-pagebreak",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_SEPARATOR\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -365,8 +385,8 @@
       "subtests": [
         {
           "name": "doc-pagelist",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -377,8 +397,8 @@
       "subtests": [
         {
           "name": "doc-part",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -389,8 +409,8 @@
       "subtests": [
         {
           "name": "doc-preface",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -401,8 +421,8 @@
       "subtests": [
         {
           "name": "doc-prologue",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -437,8 +457,8 @@
       "subtests": [
         {
           "name": "doc-subtitle",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_HEADING\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -449,8 +469,8 @@
       "subtests": [
         {
           "name": "doc-tip",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_COMMENT\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -461,8 +481,8 @@
       "subtests": [
         {
           "name": "doc-toc",
-          "status": "FAIL",
-          "message": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",

--- a/dpub-aam/FF02.json
+++ b/dpub-aam/FF02.json
@@ -17,8 +17,8 @@
       "subtests": [
         {
           "name": "doc-acknowledgments",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -29,8 +29,8 @@
       "subtests": [
         {
           "name": "doc-afterword",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -41,8 +41,8 @@
       "subtests": [
         {
           "name": "doc-appendix",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -82,8 +82,8 @@
       "subtests": [
         {
           "name": "doc-bibliography",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -111,8 +111,8 @@
       "subtests": [
         {
           "name": "doc-chapter",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -135,8 +135,8 @@
       "subtests": [
         {
           "name": "doc-conclusion",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -171,8 +171,8 @@
       "subtests": [
         {
           "name": "doc-credits",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -207,8 +207,8 @@
       "subtests": [
         {
           "name": "doc-endnotes",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -231,8 +231,8 @@
       "subtests": [
         {
           "name": "doc-epilogue",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -243,8 +243,8 @@
       "subtests": [
         {
           "name": "doc-errata",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -267,8 +267,8 @@
       "subtests": [
         {
           "name": "doc-footnote",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -279,8 +279,8 @@
       "subtests": [
         {
           "name": "doc-foreword",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -291,8 +291,8 @@
       "subtests": [
         {
           "name": "doc-glossary",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -332,8 +332,8 @@
       "subtests": [
         {
           "name": "doc-introduction",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -373,8 +373,8 @@
       "subtests": [
         {
           "name": "doc-pagebreak",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -397,8 +397,8 @@
       "subtests": [
         {
           "name": "doc-part",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -409,8 +409,8 @@
       "subtests": [
         {
           "name": "doc-preface",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -421,8 +421,8 @@
       "subtests": [
         {
           "name": "doc-prologue",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -457,8 +457,8 @@
       "subtests": [
         {
           "name": "doc-subtitle",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is heading\" failed   \n**Actual value:** AXHeading  \n;  expected true got false"
         }
       ],
       "status": "OK",

--- a/dpub-aam/FF03.json
+++ b/dpub-aam/FF03.json
@@ -53,13 +53,13 @@
       "subtests": [
         {
           "name": "doc-backlink",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property interfaces contains IAccessibleHypertext2\" failed ;  expected true got false"
         },
         {
           "name": "doc-backlink 1",
           "status": "FAIL",
-          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
+          "message": "assert_false: NOTRUN: No assertion for API IAccessible2 expected false got true"
         }
       ],
       "status": "OK",
@@ -94,13 +94,13 @@
       "subtests": [
         {
           "name": "doc-biblioref",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property interfaces contains IAccessibleHypertext2\" failed ;  expected true got false"
         },
         {
           "name": "doc-biblioref 1",
           "status": "FAIL",
-          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
+          "message": "assert_false: NOTRUN: No assertion for API IAccessible2 expected false got true"
         }
       ],
       "status": "OK",
@@ -303,13 +303,13 @@
       "subtests": [
         {
           "name": "doc-glossref",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property interfaces contains IAccessibleHypertext2\" failed ;  expected true got false"
         },
         {
           "name": "doc-glossref 1",
           "status": "FAIL",
-          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
+          "message": "assert_false: NOTRUN: No assertion for API IAccessible2 expected false got true"
         }
       ],
       "status": "OK",
@@ -344,13 +344,13 @@
       "subtests": [
         {
           "name": "doc-noteref",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property interfaces contains IAccessibleHypertext2\" failed ;  expected true got false"
         },
         {
           "name": "doc-noteref 1",
           "status": "FAIL",
-          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
+          "message": "assert_false: NOTRUN: No assertion for API IAccessible2 expected false got true"
         }
       ],
       "status": "OK",

--- a/dpub-aam/GC02.json
+++ b/dpub-aam/GC02.json
@@ -6,7 +6,7 @@
         {
           "name": "doc-abstract",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-abstract  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -18,7 +18,7 @@
         {
           "name": "doc-acknowledgments",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-acknowledgments  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -30,7 +30,7 @@
         {
           "name": "doc-afterword",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-afterword  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -42,7 +42,7 @@
         {
           "name": "doc-appendix",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-appendix  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -54,7 +54,12 @@
         {
           "name": "doc-backlink",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXLink\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is link\" failed   \n**Actual value:** doc-backlink  \n;  expected true got false"
+        },
+        {
+          "name": "doc-backlink 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -66,7 +71,7 @@
         {
           "name": "doc-biblioentry",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-biblioentry  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -78,7 +83,7 @@
         {
           "name": "doc-bibliography",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-bibliography  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -90,7 +95,12 @@
         {
           "name": "doc-biblioref",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXLink\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is link\" failed   \n**Actual value:** doc-biblioref  \n;  expected true got false"
+        },
+        {
+          "name": "doc-biblioref 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -102,7 +112,7 @@
         {
           "name": "doc-chapter",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-chapter  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -114,7 +124,7 @@
         {
           "name": "doc-colophon",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-colophon  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -126,7 +136,7 @@
         {
           "name": "doc-conclusion",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-conclusion  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -138,7 +148,7 @@
         {
           "name": "doc-cover",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRole is AXImage\" failed ; \"property AXRoleDescription is image\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXImage\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is image\" failed   \n**Actual value:** doc-cover  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -150,7 +160,7 @@
         {
           "name": "doc-credit",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-credit  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -162,7 +172,7 @@
         {
           "name": "doc-credits",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-credits  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -174,7 +184,7 @@
         {
           "name": "doc-dedication",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-dedication  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -185,8 +195,8 @@
       "subtests": [
         {
           "name": "doc-endnote",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -198,7 +208,7 @@
         {
           "name": "doc-endnotes",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-endnotes  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -210,7 +220,7 @@
         {
           "name": "doc-epigraph",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-epigraph  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -222,7 +232,7 @@
         {
           "name": "doc-epilogue",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-epilogue  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -234,7 +244,7 @@
         {
           "name": "doc-errata",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-errata  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -246,7 +256,7 @@
         {
           "name": "doc-example",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-example  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -258,7 +268,7 @@
         {
           "name": "doc-footnote",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-footnote  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -270,7 +280,7 @@
         {
           "name": "doc-foreword",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-foreword  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -282,7 +292,7 @@
         {
           "name": "doc-glossary",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-glossary  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -294,7 +304,12 @@
         {
           "name": "doc-glossref",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXLink\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is link\" failed   \n**Actual value:** doc-glossref  \n;  expected true got false"
+        },
+        {
+          "name": "doc-glossref 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -306,7 +321,7 @@
         {
           "name": "doc-index",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is navigation\" failed   \n**Actual value:** doc-index  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -318,7 +333,7 @@
         {
           "name": "doc-introduction",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-introduction  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -330,7 +345,12 @@
         {
           "name": "doc-noteref",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXLink\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is link\" failed   \n**Actual value:** doc-noteref  \n;  expected true got false"
+        },
+        {
+          "name": "doc-noteref 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -342,7 +362,7 @@
         {
           "name": "doc-notice",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXDocumentNote\" failed ; \"property AXRoleDescription is note\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXDocumentNote\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is note\" failed   \n**Actual value:** doc-notice  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -354,7 +374,7 @@
         {
           "name": "doc-pagebreak",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRole is AXSplitter\" failed ; \"property AXRoleDescription is splitter\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXSplitter\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** doc-pagebreak  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -366,7 +386,7 @@
         {
           "name": "doc-pagelist",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is navigation\" failed   \n**Actual value:** doc-pagelist  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -378,7 +398,7 @@
         {
           "name": "doc-part",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-part  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -390,7 +410,7 @@
         {
           "name": "doc-preface",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-preface  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -402,7 +422,7 @@
         {
           "name": "doc-prologue",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-prologue  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -414,7 +434,7 @@
         {
           "name": "doc-pullquote",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-pullquote  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -426,7 +446,7 @@
         {
           "name": "doc-qna",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-qna  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -438,7 +458,7 @@
         {
           "name": "doc-subtitle",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRole is AXHeading\" failed ; \"property AXRoleDescription is heading\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXHeading\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is heading\" failed   \n**Actual value:** doc-subtitle  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -450,7 +470,7 @@
         {
           "name": "doc-tip",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXDocumentNote\" failed ; \"property AXRoleDescription is note\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXDocumentNote\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is note\" failed   \n**Actual value:** doc-tip  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -462,7 +482,7 @@
         {
           "name": "doc-toc",
           "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is navigation\" failed   \n**Actual value:** doc-toc  \n;  expected true got false"
         }
       ],
       "status": "OK",

--- a/dpub-aam/README.md
+++ b/dpub-aam/README.md
@@ -13,7 +13,7 @@ List of supported AT APIs
 =========================
 
 01. ATK
-02. AXAPI
+02. AX API
 03. IAccessible2
 04. MSAA
 05. UIA
@@ -28,15 +28,23 @@ Index of implementations in reports
   * email: jdiggs@igalia.com
   * link: <http://www.mozilla.org>
 
+* FF02 - Firefox on macOS using AX API
+  * email: jdiggs@igalia.com
+  * link: <http://www.mozilla.org>
+
+* FF03 - Firefox on Windows using IAccessible2
+  * email: jongund@illinois.edu
+  * link: <http://www.mozilla.org>
+
 * WK01 - WebKit on Linux using ATK
   * email: jdiggs@igalia.com
   * link: <https://webkitgtk.org>
 
-* WK02 - WebKit on OS X using AXAPI
+* WK02 - WebKit/Safari on macOS using AX API
   * email: jdiggs@igalia.com
   * link: <https://webkit.org>
 
-* GC02 - Chrome on OS X using AXAPI
+* GC02 - Chrome on macOS using AX API
   * email: jdiggs@igalia.com
   * link: <https://www.google.com/chrome/>
 

--- a/dpub-aam/WK01.json
+++ b/dpub-aam/WK01.json
@@ -55,6 +55,11 @@
           "name": "doc-backlink",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "doc-backlink 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -91,6 +96,11 @@
           "name": "doc-biblioref",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "doc-biblioref 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -295,6 +305,11 @@
           "name": "doc-glossref",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "doc-glossref 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -331,6 +346,11 @@
           "name": "doc-noteref",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "doc-noteref 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",

--- a/dpub-aam/all.html
+++ b/dpub-aam/all.html
@@ -55,231 +55,412 @@
 <li><a href='#test-file-38'>/dpub-aam/doc-toc-manual.html</a></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/dpub-aam/doc-abstract-manual.html' target='_blank'>/dpub-aam/doc-abstract-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-0-0' class='subtest'><td>doc-abstract</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>FF02</th><th>FF03</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/dpub-aam/doc-abstract-manual.html' target='_blank'>/dpub-aam/doc-abstract-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-0-0' class='subtest'><td>doc-abstract</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-abstract <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/dpub-aam/doc-acknowledgments-manual.html' target='_blank'>/dpub-aam/doc-acknowledgments-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-1-0' class='subtest'><td>doc-acknowledgments</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/dpub-aam/doc-acknowledgments-manual.html' target='_blank'>/dpub-aam/doc-acknowledgments-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-1-0' class='subtest'><td>doc-acknowledgments</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-acknowledgments <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/dpub-aam/doc-afterword-manual.html' target='_blank'>/dpub-aam/doc-afterword-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-2-0' class='subtest'><td>doc-afterword</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/dpub-aam/doc-afterword-manual.html' target='_blank'>/dpub-aam/doc-afterword-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-2-0' class='subtest'><td>doc-afterword</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-afterword <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/dpub-aam/doc-appendix-manual.html' target='_blank'>/dpub-aam/doc-appendix-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-3-0' class='subtest'><td>doc-appendix</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/dpub-aam/doc-appendix-manual.html' target='_blank'>/dpub-aam/doc-appendix-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-3-0' class='subtest'><td>doc-appendix</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-appendix <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/dpub-aam/doc-backlink-manual.html' target='_blank'>/dpub-aam/doc-backlink-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-4-0' class='subtest'><td>doc-backlink</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed ; "property AXRoleDescription is link" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/dpub-aam/doc-backlink-manual.html' target='_blank'>/dpub-aam/doc-backlink-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-4-0' class='subtest'><td>doc-backlink</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF03:</td><td> assert_true: "property interfaces contains IAccessibleHypertext2" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is link" failed <br />
+<strong>Actual value:</strong> doc-backlink <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/dpub-aam/doc-biblioentry-manual.html' target='_blank'>/dpub-aam/doc-biblioentry-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-5-0' class='subtest'><td>doc-biblioentry</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LIST_ITEM" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/dpub-aam/doc-biblioentry-manual.html' target='_blank'>/dpub-aam/doc-biblioentry-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-5-0' class='subtest'><td>doc-biblioentry</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-biblioentry <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/dpub-aam/doc-bibliography-manual.html' target='_blank'>/dpub-aam/doc-bibliography-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-6-0' class='subtest'><td>doc-bibliography</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/dpub-aam/doc-bibliography-manual.html' target='_blank'>/dpub-aam/doc-bibliography-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-6-0' class='subtest'><td>doc-bibliography</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-bibliography <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/dpub-aam/doc-biblioref-manual.html' target='_blank'>/dpub-aam/doc-biblioref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-7-0' class='subtest'><td>doc-biblioref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed ; "property AXRoleDescription is link" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/dpub-aam/doc-biblioref-manual.html' target='_blank'>/dpub-aam/doc-biblioref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-7-0' class='subtest'><td>doc-biblioref</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF03:</td><td> assert_true: "property interfaces contains IAccessibleHypertext2" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is link" failed <br />
+<strong>Actual value:</strong> doc-biblioref <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/dpub-aam/doc-chapter-manual.html' target='_blank'>/dpub-aam/doc-chapter-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-8-0' class='subtest'><td>doc-chapter</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/dpub-aam/doc-chapter-manual.html' target='_blank'>/dpub-aam/doc-chapter-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-8-0' class='subtest'><td>doc-chapter</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-chapter <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/dpub-aam/doc-colophon-manual.html' target='_blank'>/dpub-aam/doc-colophon-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-9-0' class='subtest'><td>doc-colophon</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/dpub-aam/doc-colophon-manual.html' target='_blank'>/dpub-aam/doc-colophon-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-9-0' class='subtest'><td>doc-colophon</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-colophon <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/dpub-aam/doc-conclusion-manual.html' target='_blank'>/dpub-aam/doc-conclusion-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-10-0' class='subtest'><td>doc-conclusion</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/dpub-aam/doc-conclusion-manual.html' target='_blank'>/dpub-aam/doc-conclusion-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-10-0' class='subtest'><td>doc-conclusion</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-conclusion <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/dpub-aam/doc-cover-manual.html' target='_blank'>/dpub-aam/doc-cover-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-11-0' class='subtest'><td>doc-cover</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>IMAGE" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXImage" failed ; "property AXRoleDescription is image" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/dpub-aam/doc-cover-manual.html' target='_blank'>/dpub-aam/doc-cover-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-11-0' class='subtest'><td>doc-cover</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXImage" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is image" failed <br />
+<strong>Actual value:</strong> doc-cover <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/dpub-aam/doc-credit-manual.html' target='_blank'>/dpub-aam/doc-credit-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-12-0' class='subtest'><td>doc-credit</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/dpub-aam/doc-credit-manual.html' target='_blank'>/dpub-aam/doc-credit-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-12-0' class='subtest'><td>doc-credit</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-credit <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/dpub-aam/doc-credits-manual.html' target='_blank'>/dpub-aam/doc-credits-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-13-0' class='subtest'><td>doc-credits</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/dpub-aam/doc-credits-manual.html' target='_blank'>/dpub-aam/doc-credits-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-13-0' class='subtest'><td>doc-credits</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-credits <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/dpub-aam/doc-dedication-manual.html' target='_blank'>/dpub-aam/doc-dedication-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-14-0' class='subtest'><td>doc-dedication</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/dpub-aam/doc-dedication-manual.html' target='_blank'>/dpub-aam/doc-dedication-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-14-0' class='subtest'><td>doc-dedication</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-dedication <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/dpub-aam/doc-endnote-manual.html' target='_blank'>/dpub-aam/doc-endnote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-15-0' class='subtest'><td>doc-endnote</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LIST_ITEM" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/dpub-aam/doc-endnote-manual.html' target='_blank'>/dpub-aam/doc-endnote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-15-0' class='subtest'><td>doc-endnote</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/dpub-aam/doc-endnotes-manual.html' target='_blank'>/dpub-aam/doc-endnotes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-16-0' class='subtest'><td>doc-endnotes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-endnotes <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/dpub-aam/doc-endnotes-manual.html' target='_blank'>/dpub-aam/doc-endnotes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-16-0' class='subtest'><td>doc-endnotes</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/dpub-aam/doc-epigraph-manual.html' target='_blank'>/dpub-aam/doc-epigraph-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-17-0' class='subtest'><td>doc-epigraph</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-epigraph <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/dpub-aam/doc-epigraph-manual.html' target='_blank'>/dpub-aam/doc-epigraph-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-17-0' class='subtest'><td>doc-epigraph</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/dpub-aam/doc-epilogue-manual.html' target='_blank'>/dpub-aam/doc-epilogue-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-18-0' class='subtest'><td>doc-epilogue</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-epilogue <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/dpub-aam/doc-epilogue-manual.html' target='_blank'>/dpub-aam/doc-epilogue-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-18-0' class='subtest'><td>doc-epilogue</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/dpub-aam/doc-errata-manual.html' target='_blank'>/dpub-aam/doc-errata-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-19-0' class='subtest'><td>doc-errata</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-errata <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/dpub-aam/doc-errata-manual.html' target='_blank'>/dpub-aam/doc-errata-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-19-0' class='subtest'><td>doc-errata</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/dpub-aam/doc-example-manual.html' target='_blank'>/dpub-aam/doc-example-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-20-0' class='subtest'><td>doc-example</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-example <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/dpub-aam/doc-example-manual.html' target='_blank'>/dpub-aam/doc-example-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-20-0' class='subtest'><td>doc-example</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/dpub-aam/doc-footnote-manual.html' target='_blank'>/dpub-aam/doc-footnote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-21-0' class='subtest'><td>doc-footnote</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-footnote <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/dpub-aam/doc-footnote-manual.html' target='_blank'>/dpub-aam/doc-footnote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-21-0' class='subtest'><td>doc-footnote</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>FOOTNOTE" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a "footnote" role;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-22'><td><a href='http://www.w3c-test.org/dpub-aam/doc-foreword-manual.html' target='_blank'>/dpub-aam/doc-foreword-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-22-0' class='subtest'><td>doc-foreword</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-foreword <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-22'><td><a href='http://www.w3c-test.org/dpub-aam/doc-foreword-manual.html' target='_blank'>/dpub-aam/doc-foreword-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-22-0' class='subtest'><td>doc-foreword</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/dpub-aam/doc-glossary-manual.html' target='_blank'>/dpub-aam/doc-glossary-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-23-0' class='subtest'><td>doc-glossary</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-glossary <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/dpub-aam/doc-glossary-manual.html' target='_blank'>/dpub-aam/doc-glossary-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-23-0' class='subtest'><td>doc-glossary</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/dpub-aam/doc-glossref-manual.html' target='_blank'>/dpub-aam/doc-glossref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-24-0' class='subtest'><td>doc-glossref</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF03:</td><td> assert_true: "property interfaces contains IAccessibleHypertext2" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is link" failed <br />
+<strong>Actual value:</strong> doc-glossref <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/dpub-aam/doc-glossref-manual.html' target='_blank'>/dpub-aam/doc-glossref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-24-0' class='subtest'><td>doc-glossref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed ; "property AXRoleDescription is link" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/dpub-aam/doc-index-manual.html' target='_blank'>/dpub-aam/doc-index-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-25-0' class='subtest'><td>doc-index</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is navigation" failed <br />
+<strong>Actual value:</strong> doc-index <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/dpub-aam/doc-index-manual.html' target='_blank'>/dpub-aam/doc-index-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-25-0' class='subtest'><td>doc-index</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed ; "property AXRoleDescription is navigation" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-26'><td><a href='http://www.w3c-test.org/dpub-aam/doc-introduction-manual.html' target='_blank'>/dpub-aam/doc-introduction-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-26-0' class='subtest'><td>doc-introduction</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-introduction <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-26'><td><a href='http://www.w3c-test.org/dpub-aam/doc-introduction-manual.html' target='_blank'>/dpub-aam/doc-introduction-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-26-0' class='subtest'><td>doc-introduction</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/dpub-aam/doc-noteref-manual.html' target='_blank'>/dpub-aam/doc-noteref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-27-0' class='subtest'><td>doc-noteref</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF03:</td><td> assert_true: "property interfaces contains IAccessibleHypertext2" failed ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is link" failed <br />
+<strong>Actual value:</strong> doc-noteref <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/dpub-aam/doc-noteref-manual.html' target='_blank'>/dpub-aam/doc-noteref-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-27-0' class='subtest'><td>doc-noteref</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LINK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXLink" failed ; "property AXRoleDescription is link" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/dpub-aam/doc-notice-manual.html' target='_blank'>/dpub-aam/doc-notice-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-28-0' class='subtest'><td>doc-notice</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXDocumentNote" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is note" failed <br />
+<strong>Actual value:</strong> doc-notice <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/dpub-aam/doc-notice-manual.html' target='_blank'>/dpub-aam/doc-notice-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-28-0' class='subtest'><td>doc-notice</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>COMMENT" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXDocumentNote" failed ; "property AXRoleDescription is note" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-29'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pagebreak-manual.html' target='_blank'>/dpub-aam/doc-pagebreak-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-29-0' class='subtest'><td>doc-pagebreak</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXContentSeparator <br />
+; "property AXRoleDescription is splitter" failed <br />
+<strong>Actual value:</strong> separator <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXSplitter" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is splitter" failed <br />
+<strong>Actual value:</strong> doc-pagebreak <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-29'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pagebreak-manual.html' target='_blank'>/dpub-aam/doc-pagebreak-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-29-0' class='subtest'><td>doc-pagebreak</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>SEPARATOR" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXSplitter" failed ; "property AXRoleDescription is splitter" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-30'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pagelist-manual.html' target='_blank'>/dpub-aam/doc-pagelist-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-30-0' class='subtest'><td>doc-pagelist</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is navigation" failed <br />
+<strong>Actual value:</strong> doc-pagelist <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-30'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pagelist-manual.html' target='_blank'>/dpub-aam/doc-pagelist-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-30-0' class='subtest'><td>doc-pagelist</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed ; "property AXRoleDescription is navigation" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/dpub-aam/doc-part-manual.html' target='_blank'>/dpub-aam/doc-part-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-31-0' class='subtest'><td>doc-part</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-part <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/dpub-aam/doc-part-manual.html' target='_blank'>/dpub-aam/doc-part-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-31-0' class='subtest'><td>doc-part</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-32'><td><a href='http://www.w3c-test.org/dpub-aam/doc-preface-manual.html' target='_blank'>/dpub-aam/doc-preface-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-32-0' class='subtest'><td>doc-preface</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-preface <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-32'><td><a href='http://www.w3c-test.org/dpub-aam/doc-preface-manual.html' target='_blank'>/dpub-aam/doc-preface-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-32-0' class='subtest'><td>doc-preface</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/dpub-aam/doc-prologue-manual.html' target='_blank'>/dpub-aam/doc-prologue-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-33-0' class='subtest'><td>doc-prologue</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is region" failed <br />
+<strong>Actual value:</strong> doc-prologue <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/dpub-aam/doc-prologue-manual.html' target='_blank'>/dpub-aam/doc-prologue-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-33-0' class='subtest'><td>doc-prologue</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed ; "property AXRoleDescription is region" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pullquote-manual.html' target='_blank'>/dpub-aam/doc-pullquote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-34-0' class='subtest'><td>doc-pullquote</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-pullquote <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/dpub-aam/doc-pullquote-manual.html' target='_blank'>/dpub-aam/doc-pullquote-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-34-0' class='subtest'><td>doc-pullquote</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/dpub-aam/doc-qna-manual.html' target='_blank'>/dpub-aam/doc-qna-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-35-0' class='subtest'><td>doc-qna</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> doc-qna <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/dpub-aam/doc-qna-manual.html' target='_blank'>/dpub-aam/doc-qna-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-35-0' class='subtest'><td>doc-qna</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed ; "property AXRoleDescription is group" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/dpub-aam/doc-subtitle-manual.html' target='_blank'>/dpub-aam/doc-subtitle-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-36-0' class='subtest'><td>doc-subtitle</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is heading" failed <br />
+<strong>Actual value:</strong> AXHeading <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXHeading" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is heading" failed <br />
+<strong>Actual value:</strong> doc-subtitle <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/dpub-aam/doc-subtitle-manual.html' target='_blank'>/dpub-aam/doc-subtitle-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-36-0' class='subtest'><td>doc-subtitle</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>HEADING" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXHeading" failed ; "property AXRoleDescription is heading" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/dpub-aam/doc-tip-manual.html' target='_blank'>/dpub-aam/doc-tip-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-37-0' class='subtest'><td>doc-tip</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXDocumentNote" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is note" failed <br />
+<strong>Actual value:</strong> doc-tip <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/dpub-aam/doc-tip-manual.html' target='_blank'>/dpub-aam/doc-tip-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-37-0' class='subtest'><td>doc-tip</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>COMMENT" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXDocumentNote" failed ; "property AXRoleDescription is note" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/dpub-aam/doc-toc-manual.html' target='_blank'>/dpub-aam/doc-toc-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-38-0' class='subtest'><td>doc-toc</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property role is ROLE</em>LANDMARK" failed ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed ; "property AXRoleDescription is navigation" failed ;  expected true got false</td></tr>
+<tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/dpub-aam/doc-toc-manual.html' target='_blank'>/dpub-aam/doc-toc-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-38-0' class='subtest'><td>doc-toc</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='8'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkNavigation" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is navigation" failed <br />
+<strong>Actual value:</strong> doc-toc <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> <a href="https://status.modern.ie/#digitalpublishingaccessibilityapimappings">https://status.modern.ie/#digitalpublishingaccessibilityapimappings</a></td></tr>
 </table></td></tr>
 

--- a/dpub-aam/complete-fails.html
+++ b/dpub-aam/complete-fails.html
@@ -16,7 +16,7 @@
       <h3>Test Files</h3>
 <ol class='toc'></ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>FF02</th><th>FF03</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
 
       </table>
     </div>

--- a/dpub-aam/consolidated.json
+++ b/dpub-aam/consolidated.json
@@ -1,6 +1,8 @@
 {
   "ua": [
     "FF01",
+    "FF02",
+    "FF03",
     "GC02",
     "ME05",
     "WK01",
@@ -10,6 +12,8 @@
     "/dpub-aam/doc-abstract-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -17,24 +21,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-abstract": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-abstract  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 5,
             "FAIL": 2
           }
         }
@@ -43,6 +49,8 @@
     "/dpub-aam/doc-acknowledgments-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -50,26 +58,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-acknowledgments": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-acknowledgments  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -77,6 +87,8 @@
     "/dpub-aam/doc-afterword-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -84,26 +96,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-afterword": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-afterword  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -111,6 +125,8 @@
     "/dpub-aam/doc-appendix-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -118,26 +134,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-appendix": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-appendix  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -145,6 +163,8 @@
     "/dpub-aam/doc-backlink-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -152,26 +172,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-backlink": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "FAIL",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false",
+            "FF03": "assert_true: \"property interfaces contains IAccessibleHypertext2\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXRole is AXLink\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is link\" failed   \n**Actual value:** doc-backlink  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -179,6 +201,8 @@
     "/dpub-aam/doc-biblioentry-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -186,26 +210,27 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-biblioentry": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LIST_ITEM\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-biblioentry  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 5,
+            "FAIL": 2
           }
         }
       }
@@ -213,6 +238,8 @@
     "/dpub-aam/doc-bibliography-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -220,26 +247,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-bibliography": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-bibliography  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -247,6 +276,8 @@
     "/dpub-aam/doc-biblioref-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -254,26 +285,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-biblioref": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "FAIL",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false",
+            "FF03": "assert_true: \"property interfaces contains IAccessibleHypertext2\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXRole is AXLink\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is link\" failed   \n**Actual value:** doc-biblioref  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -281,6 +314,8 @@
     "/dpub-aam/doc-chapter-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -288,26 +323,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-chapter": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-chapter  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -315,6 +352,8 @@
     "/dpub-aam/doc-colophon-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -322,24 +361,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-colophon": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-colophon  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 5,
             "FAIL": 2
           }
         }
@@ -348,6 +389,8 @@
     "/dpub-aam/doc-conclusion-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -355,26 +398,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-conclusion": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-conclusion  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -382,6 +427,8 @@
     "/dpub-aam/doc-cover-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -389,26 +436,27 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-cover": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_IMAGE\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXImage\" failed ; \"property AXRoleDescription is image\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXRole is AXImage\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is image\" failed   \n**Actual value:** doc-cover  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 5,
+            "FAIL": 2
           }
         }
       }
@@ -416,6 +464,8 @@
     "/dpub-aam/doc-credit-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -423,24 +473,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-credit": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-credit  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 5,
             "FAIL": 2
           }
         }
@@ -449,6 +501,8 @@
     "/dpub-aam/doc-credits-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -456,26 +510,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-credits": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-credits  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -483,6 +539,8 @@
     "/dpub-aam/doc-dedication-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -490,24 +548,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-dedication": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-dedication  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 5,
             "FAIL": 2
           }
         }
@@ -516,6 +576,8 @@
     "/dpub-aam/doc-endnote-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -523,26 +585,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-endnote": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
-            "GC02": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
+            "GC02": "PASS",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LIST_ITEM\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRoleDescription is group\" failed ;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 6,
+            "FAIL": 1
           }
         }
       }
@@ -550,6 +612,8 @@
     "/dpub-aam/doc-endnotes-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -557,26 +621,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-endnotes": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-endnotes  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -584,6 +650,8 @@
     "/dpub-aam/doc-epigraph-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -591,24 +659,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-epigraph": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-epigraph  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 5,
             "FAIL": 2
           }
         }
@@ -617,6 +687,8 @@
     "/dpub-aam/doc-epilogue-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -624,26 +696,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-epilogue": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-epilogue  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -651,6 +725,8 @@
     "/dpub-aam/doc-errata-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -658,26 +734,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-errata": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-errata  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -685,6 +763,8 @@
     "/dpub-aam/doc-example-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -692,24 +772,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-example": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-example  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 5,
             "FAIL": 2
           }
         }
@@ -718,6 +800,8 @@
     "/dpub-aam/doc-footnote-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -725,26 +809,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-footnote": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_FOOTNOTE\" failed https://bugzilla.gnome.org/show_bug.cgi?id=748384: Bug 748384 – We need a \"footnote\" role;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-footnote  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -752,6 +838,8 @@
     "/dpub-aam/doc-foreword-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -759,26 +847,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-foreword": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-foreword  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -786,6 +876,8 @@
     "/dpub-aam/doc-glossary-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -793,26 +885,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-glossary": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-glossary  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -820,6 +914,8 @@
     "/dpub-aam/doc-glossref-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -827,26 +923,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-glossref": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "FAIL",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false",
+            "FF03": "assert_true: \"property interfaces contains IAccessibleHypertext2\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXRole is AXLink\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is link\" failed   \n**Actual value:** doc-glossref  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -854,6 +952,8 @@
     "/dpub-aam/doc-index-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -861,26 +961,27 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-index": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is navigation\" failed   \n**Actual value:** doc-index  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 5,
+            "FAIL": 2
           }
         }
       }
@@ -888,6 +989,8 @@
     "/dpub-aam/doc-introduction-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -895,26 +998,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-introduction": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-introduction  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -922,6 +1027,8 @@
     "/dpub-aam/doc-noteref-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -929,26 +1036,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-noteref": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "FAIL",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LINK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXLink\" failed ; \"property AXRoleDescription is link\" failed ;  expected true got false",
+            "FF03": "assert_true: \"property interfaces contains IAccessibleHypertext2\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXRole is AXLink\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is link\" failed   \n**Actual value:** doc-noteref  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -956,6 +1065,8 @@
     "/dpub-aam/doc-notice-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -963,26 +1074,27 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-notice": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_COMMENT\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXDocumentNote\" failed ; \"property AXRoleDescription is note\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXDocumentNote\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is note\" failed   \n**Actual value:** doc-notice  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 5,
+            "FAIL": 2
           }
         }
       }
@@ -990,6 +1102,8 @@
     "/dpub-aam/doc-pagebreak-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -997,26 +1111,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-pagebreak": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_SEPARATOR\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXSplitter\" failed ; \"property AXRoleDescription is splitter\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXRole is AXSplitter\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** doc-pagebreak  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -1024,6 +1140,8 @@
     "/dpub-aam/doc-pagelist-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1031,26 +1149,27 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-pagelist": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is navigation\" failed   \n**Actual value:** doc-pagelist  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 5,
+            "FAIL": 2
           }
         }
       }
@@ -1058,6 +1177,8 @@
     "/dpub-aam/doc-part-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1065,26 +1186,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-part": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-part  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -1092,6 +1215,8 @@
     "/dpub-aam/doc-preface-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1099,26 +1224,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-preface": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-preface  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -1126,6 +1253,8 @@
     "/dpub-aam/doc-prologue-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1133,26 +1262,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-prologue": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed ; \"property AXRoleDescription is region\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is region\" failed   \n**Actual value:** doc-prologue  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -1160,6 +1291,8 @@
     "/dpub-aam/doc-pullquote-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1167,24 +1300,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-pullquote": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-pullquote  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 5,
             "FAIL": 2
           }
         }
@@ -1193,6 +1328,8 @@
     "/dpub-aam/doc-qna-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1200,24 +1337,26 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-qna": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed ; \"property AXRoleDescription is group\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** doc-qna  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 5,
             "FAIL": 2
           }
         }
@@ -1226,6 +1365,8 @@
     "/dpub-aam/doc-subtitle-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1233,26 +1374,28 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-subtitle": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_HEADING\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXHeading\" failed ; \"property AXRoleDescription is heading\" failed ;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is heading\" failed   \n**Actual value:** AXHeading  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXRole is AXHeading\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is heading\" failed   \n**Actual value:** doc-subtitle  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 3
           }
         }
       }
@@ -1260,6 +1403,8 @@
     "/dpub-aam/doc-tip-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1267,26 +1412,27 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-tip": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_COMMENT\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXDocumentNote\" failed ; \"property AXRoleDescription is note\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXDocumentNote\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is note\" failed   \n**Actual value:** doc-tip  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 5,
+            "FAIL": 2
           }
         }
       }
@@ -1294,6 +1440,8 @@
     "/dpub-aam/doc-toc-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
+        "FF03": "OK",
         "GC02": "OK",
         "ME05": "OK",
         "WK01": "OK",
@@ -1301,26 +1449,27 @@
       },
       "UAmessage": {},
       "totals": {
-        "OK": 5
+        "OK": 7
       },
       "subtests": {
         "doc-toc": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "ME05": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"property role is ROLE_LANDMARK\" failed ;  expected true got false",
-            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed ; \"property AXRoleDescription is navigation\" failed ;  expected true got false",
+            "GC02": "assert_true: \"property AXSubrole is AXLandmarkNavigation\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is navigation\" failed   \n**Actual value:** doc-toc  \n;  expected true got false",
             "ME05": "<https://status.modern.ie/#digitalpublishingaccessibilityapimappings>"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 5,
+            "FAIL": 2
           }
         }
       }

--- a/dpub-aam/less-than-2.html
+++ b/dpub-aam/less-than-2.html
@@ -16,7 +16,7 @@
       <h3>Test Files</h3>
 <ol class='toc'></ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>FF02</th><th>FF03</th><th>GC02</th><th>ME05</th><th>WK01</th><th>WK02</th></tr></thead>
 
       </table>
     </div>

--- a/wai-aria/FF01.json
+++ b/wai-aria/FF01.json
@@ -7,6 +7,11 @@
           "name": "alertdialog modal false",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "alertdialog modal false 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -19,6 +24,11 @@
           "name": "alertdialog modal true",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "alertdialog modal true 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -35,7 +45,7 @@
         {
           "name": "application activedescendant 1",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false"
+          "message": "assert\\_true: \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -52,7 +62,7 @@
         {
           "name": "application activedescendant value changes 1",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false"
+          "message": "assert\\_true: \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -171,13 +181,13 @@
       "subtests": [
         {
           "name": "aria-details pointing to details element",
-          "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_DETAILS is details\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "aria-details pointing to details element 1",
-          "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -188,13 +198,13 @@
       "subtests": [
         {
           "name": "aria-details pointing to div element",
-          "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_DETAILS is details\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "aria-details pointing to div element 1",
-          "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -205,8 +215,8 @@
       "subtests": [
         {
           "name": "article in feed posinset and setsize",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property role is ROLE_ARTICLE\" failed   \n**Actual value:** ROLE\\_DOCUMENT\\_FRAME  \n<https://bugzil.la/1305446>: [NEW] Expose ARIA \"article\" role as ROLE\\_ARTICLE and \"log\" role as ROLE\\_LOG  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -218,7 +228,7 @@
         {
           "name": "article in feed setsize -1",
           "status": "FAIL",
-          "message": "assert\\_true: \"property role is ROLE_ARTICLE\" failed   \n**Actual value:** ROLE\\_DOCUMENT\\_FRAME  \n<https://bugzil.la/1305446>: [NEW] Expose ARIA \"article\" role as ROLE\\_ARTICLE and \"log\" role as ROLE\\_LOG  \n; \"property objectAttributes contains setsize:-1\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:article', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1358473>: [NEW] Do not calculate setsize when aria-setsize has a value of -1  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains setsize:-1\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:article', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1358473>: [NEW] Do not calculate setsize when aria-setsize has a value of -1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -229,8 +239,8 @@
       "subtests": [
         {
           "name": "article not in feed posinset and setsize",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property role is ROLE_ARTICLE\" failed   \n**Actual value:** ROLE\\_DOCUMENT\\_FRAME  \n<https://bugzil.la/1305446>: [NEW] Expose ARIA \"article\" role as ROLE\\_ARTICLE and \"log\" role as ROLE\\_LOG  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -242,7 +252,7 @@
         {
           "name": "button haspopup dialog",
           "status": "FAIL",
-          "message": "assert\\_true: \"property objectAttributes contains haspopup:dialog\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:dialog\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -278,7 +288,7 @@
         {
           "name": "button haspopup foo",
           "status": "FAIL",
-          "message": "assert\\_true: \"property objectAttributes contains haspopup:false\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:false\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states doesNotContain STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_HAS\\_POPUP']  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -290,7 +300,7 @@
         {
           "name": "button haspopup grid",
           "status": "FAIL",
-          "message": "assert\\_true: \"property objectAttributes contains haspopup:grid\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:grid\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -302,7 +312,7 @@
         {
           "name": "button haspopup listbox",
           "status": "FAIL",
-          "message": "assert\\_true: \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -314,7 +324,7 @@
         {
           "name": "button haspopup menu",
           "status": "FAIL",
-          "message": "assert\\_true: \"property objectAttributes contains haspopup:menu\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:menu\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -326,7 +336,7 @@
         {
           "name": "button haspopup tree",
           "status": "FAIL",
-          "message": "assert\\_true: \"property objectAttributes contains haspopup:tree\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:tree\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -337,8 +347,8 @@
       "subtests": [
         {
           "name": "button haspopup true",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -744,7 +754,7 @@
         {
           "name": "combobox haspopup dialog",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:dialog\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:dialog\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -755,8 +765,8 @@
       "subtests": [
         {
           "name": "combobox haspopup false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert\\_true: \"property states doesNotContain STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_HAS\\_POPUP']  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -768,7 +778,7 @@
         {
           "name": "combobox haspopup grid",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:grid\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:grid\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -780,7 +790,7 @@
         {
           "name": "combobox haspopup listbox",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -792,7 +802,7 @@
         {
           "name": "combobox haspopup menu",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:menu\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:menu\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -804,7 +814,7 @@
         {
           "name": "combobox haspopup tree",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:tree\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:tree\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -815,8 +825,8 @@
       "subtests": [
         {
           "name": "combobox haspopup true",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -828,7 +838,7 @@
         {
           "name": "combobox haspopup unspecified",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
+          "message": "assert\\_true: \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -851,8 +861,8 @@
       "subtests": [
         {
           "name": "combobox orientation unspecified",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property states doesNotContain STATE\\_VERTICAL\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1357042>: [NEW] Implement or update support for exposure of aria-orientation via ATK StateSet  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -875,8 +885,8 @@
       "subtests": [
         {
           "name": "combobox readonly false",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -888,7 +898,7 @@
         {
           "name": "combobox readonly true",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property states contains STATE\\_READ_ONLY\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false"
+          "message": "assert\\_true: \"property states contains STATE\\_READ_ONLY\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_HAS\\_POPUP']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -899,8 +909,8 @@
       "subtests": [
         {
           "name": "combobox readonly unspecified",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -913,6 +923,11 @@
           "name": "dialog modal false",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "dialog modal false 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -925,6 +940,11 @@
           "name": "dialog modal true",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "dialog modal true 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -937,6 +957,11 @@
           "name": "dialog modal unspecified",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "dialog modal unspecified 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -959,13 +984,13 @@
       "subtests": [
         {
           "name": "errormessage object in invalid state",
-          "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE exists false\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "errormessage object in invalid state 1",
-          "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_ERROR_FOR exists false\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -977,12 +1002,12 @@
         {
           "name": "errormessage object in valid state",
           "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE is error\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types  \n;  expected true got false"
+          "message": "assert\\_true: \"property relations doesNotContain RELATION\\_ERROR_MESSAGE\" failed   \n**Actual value:** ['RELATION\\_LABELLED\\_BY', 'RELATION\\_ERROR\\_MESSAGE']  \n;  expected true got false"
         },
         {
           "name": "errormessage object in valid state 1",
           "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_ERROR_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types  \n;  expected true got false"
+          "message": "assert\\_true: \"property relations doesNotContain RELATION\\_ERROR_FOR\" failed   \n**Actual value:** ['RELATION\\_ERROR\\_FOR']  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2011,7 +2036,7 @@
         {
           "name": "searchbox activedescendant 1",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false"
+          "message": "assert\\_true: \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2028,7 +2053,7 @@
         {
           "name": "searchbox activedescendant value changes 1",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false"
+          "message": "assert\\_true: \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2436,7 +2461,7 @@
         {
           "name": "switch checked mixed",
           "status": "FAIL",
-          "message": "assert\\_true: \"property states doesNotContain STATE\\_CHECKED\" failed   \n**Actual value:** ['STATE\\_CHECKED', 'STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_CHECKABLE']  \n<https://bugzil.la/1358447>: [NEW] Elements with aria-checked=\"mixed\" and role=\"switch\" should not expose ATK\\_STATE\\_CHECKED  \n;  expected true got false"
+          "message": "assert\\_true: \"property states doesNotContain STATE\\_CHECKED\" failed   \n**Actual value:** ['STATE\\_CHECKED', 'STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_CHECKABLE']  \n<https://bugzil.la/1358447>: [NEW] Elements which do not support aria-checked=\"mixed\" should not expose \"checked\" accessibility state  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2615,8 +2640,8 @@
       "subtests": [
         {
           "name": "term role",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property role is ROLE_DESCRIPTION_TERM\" failed   \n**Actual value:** ROLE\\_SECTION  \n<https://bugzil.la/1358417>: [NEW] ARIA term role should be exposed with ATK\\_ROLE\\_DESCRIPTION\\_TERM  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -2735,8 +2760,8 @@
       "subtests": [
         {
           "name": "treegrid orientation unspecified",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property states doesNotContain STATE\\_VERTICAL\" failed   \n**Actual value:** ['STATE\\_EDITABLE', 'STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE']  \n<https://bugzil.la/1357042>: [NEW] Implement or update support for exposure of aria-orientation via ATK StateSet  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -2771,8 +2796,8 @@
       "subtests": [
         {
           "name": "treeitem selected false",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property role is ROLE_TREE_ITEM\" failed   \n**Actual value:** ROLE\\_LIST\\_ITEM  \n<https://bugzil.la/1355423>: [NEW] ARIA treeitem role should be mapped as ATK\\_ROLE\\_TREE\\_ITEM; not ATK\\_ROLE\\_LIST\\_ITEM  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -2783,8 +2808,8 @@
       "subtests": [
         {
           "name": "treeitem selected true",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property role is ROLE_TREE_ITEM\" failed   \n**Actual value:** ROLE\\_LIST\\_ITEM  \n<https://bugzil.la/1355423>: [NEW] ARIA treeitem role should be mapped as ATK\\_ROLE\\_TREE\\_ITEM; not ATK\\_ROLE\\_LIST\\_ITEM  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -2795,8 +2820,8 @@
       "subtests": [
         {
           "name": "treeitem selected undefined",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property role is ROLE_TREE_ITEM\" failed   \n**Actual value:** ROLE\\_LIST\\_ITEM  \n<https://bugzil.la/1355423>: [NEW] ARIA treeitem role should be mapped as ATK\\_ROLE\\_TREE\\_ITEM; not ATK\\_ROLE\\_LIST\\_ITEM  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",

--- a/wai-aria/FF02.json
+++ b/wai-aria/FF02.json
@@ -5,8 +5,8 @@
       "subtests": [
         {
           "name": "alertdialog modal false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web alert dialog\" failed   \n**Actual value:** alert dialog  \n;  expected true got false"
         },
         {
           "name": "alertdialog modal false 1",
@@ -22,13 +22,13 @@
       "subtests": [
         {
           "name": "alertdialog modal true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web alert dialog\" failed   \n**Actual value:** alert dialog  \n;  expected true got false"
         },
         {
           "name": "alertdialog modal true 1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -40,12 +40,12 @@
         {
           "name": "application activedescendant",
           "status": "FAIL",
-          "message": "assert_true: \"property AXFocused is false\" failed   \n**Actual value:** true  \n;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXWebApplication\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is web application\" failed   \n**Actual value:** group  \n;  expected true got false"
         },
         {
           "name": "application activedescendant 1",
           "status": "FAIL",
-          "message": "assert_true: \"property AXFocused is true\" failed   \n**Actual value:** false  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -57,12 +57,12 @@
         {
           "name": "application activedescendant value changes",
           "status": "FAIL",
-          "message": "assert_true: \"property AXFocused is false\" failed   \n**Actual value:** true  \n; \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXWebApplication\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is web application\" failed   \n**Actual value:** group  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false"
         },
         {
           "name": "application activedescendant value changes 1",
           "status": "FAIL",
-          "message": "assert_true: \"property AXFocused is true\" failed   \n**Actual value:** false  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -73,8 +73,8 @@
       "subtests": [
         {
           "name": "aria-current not declared",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIACurrent is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -85,8 +85,8 @@
       "subtests": [
         {
           "name": "aria-current with value changes",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIACurrent contains false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -97,8 +97,8 @@
       "subtests": [
         {
           "name": "aria-current with value date",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXARIACurrent is date\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -109,8 +109,8 @@
       "subtests": [
         {
           "name": "aria-current with value location",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIACurrent is location\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -121,8 +121,8 @@
       "subtests": [
         {
           "name": "aria-current with value page",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIACurrent is page\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -133,8 +133,8 @@
       "subtests": [
         {
           "name": "aria-current with value step",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIACurrent is step\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -145,8 +145,8 @@
       "subtests": [
         {
           "name": "aria-current with value time",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXARIACurrent is time\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -157,8 +157,8 @@
       "subtests": [
         {
           "name": "aria-current with value true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIACurrent is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -169,8 +169,8 @@
       "subtests": [
         {
           "name": "aria-current with value unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIACurrent is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -182,7 +182,7 @@
         {
           "name": "aria-details pointing to details element",
           "status": "FAIL",
-          "message": "assert_true: \"property TBD is TBD\" failed <https://webkit.org/b/165842>  \n;  expected true got false"
+          "message": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false"
         },
         {
           "name": "aria-details pointing to details element 1",
@@ -199,7 +199,7 @@
         {
           "name": "aria-details pointing to div element",
           "status": "FAIL",
-          "message": "assert_true: \"property TBD is TBD\" failed <https://webkit.org/b/165842>  \n;  expected true got false"
+          "message": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false"
         },
         {
           "name": "aria-details pointing to div element 1",
@@ -215,8 +215,8 @@
       "subtests": [
         {
           "name": "article in feed posinset and setsize",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -227,8 +227,8 @@
       "subtests": [
         {
           "name": "article in feed setsize -1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIASetSize is -1\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -239,8 +239,8 @@
       "subtests": [
         {
           "name": "article not in feed posinset and setsize",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -251,8 +251,8 @@
       "subtests": [
         {
           "name": "button haspopup dialog",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -264,7 +264,7 @@
         {
           "name": "button haspopup emptystring",
           "status": "FAIL",
-          "message": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -276,7 +276,7 @@
         {
           "name": "button haspopup false",
           "status": "FAIL",
-          "message": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -288,7 +288,7 @@
         {
           "name": "button haspopup foo",
           "status": "FAIL",
-          "message": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -299,8 +299,8 @@
       "subtests": [
         {
           "name": "button haspopup grid",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -311,8 +311,8 @@
       "subtests": [
         {
           "name": "button haspopup listbox",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -323,8 +323,8 @@
       "subtests": [
         {
           "name": "button haspopup menu",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -335,8 +335,8 @@
       "subtests": [
         {
           "name": "button haspopup tree",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -347,8 +347,8 @@
       "subtests": [
         {
           "name": "button haspopup true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXMenuButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** menu button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** []  \n; \"property actions contains AXPress\" failed   \n**Actual value:** []  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -360,7 +360,7 @@
         {
           "name": "button haspopup unspecified",
           "status": "FAIL",
-          "message": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -383,8 +383,8 @@
       "subtests": [
         {
           "name": "button roledescription valid",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is SassyButton\" failed   \n**Actual value:** button  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -407,13 +407,13 @@
       "subtests": [
         {
           "name": "cell",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         },
         {
           "name": "cell 1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -424,8 +424,8 @@
       "subtests": [
         {
           "name": "cell aria-colspan 2 on div",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -436,8 +436,8 @@
       "subtests": [
         {
           "name": "cell aria-colspan 2 on td html colspan 3",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -460,8 +460,8 @@
       "subtests": [
         {
           "name": "cell aria-colspan 2 on td html colspan 3 with three actual columns",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -472,8 +472,8 @@
       "subtests": [
         {
           "name": "cell aria-colspan 2 on td with html colspan not specified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -484,8 +484,8 @@
       "subtests": [
         {
           "name": "cell aria-rowspan 2 on div",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -496,8 +496,8 @@
       "subtests": [
         {
           "name": "cell aria-rowspan 2 on td html rowspan 3",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -508,8 +508,8 @@
       "subtests": [
         {
           "name": "cell aria-rowspan 2 on td html rowspan 3 with three actual rows",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -520,8 +520,8 @@
       "subtests": [
         {
           "name": "cell aria-rowspan 2 on td with html rowspan not specified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -532,8 +532,8 @@
       "subtests": [
         {
           "name": "cell colindex 4",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -544,8 +544,8 @@
       "subtests": [
         {
           "name": "cell rowindex 4",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -556,8 +556,8 @@
       "subtests": [
         {
           "name": "checkbox readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -580,8 +580,8 @@
       "subtests": [
         {
           "name": "checkbox readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -592,8 +592,8 @@
       "subtests": [
         {
           "name": "columnheader aria-colspan 2 on div",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -628,8 +628,8 @@
       "subtests": [
         {
           "name": "columnheader aria-colspan 2 on th with html colspan not specified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -640,8 +640,8 @@
       "subtests": [
         {
           "name": "columnheader aria-rowspan 2 on div",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -676,8 +676,8 @@
       "subtests": [
         {
           "name": "columnheader aria-rowspan 2 on th with html rowspan not specified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -688,8 +688,8 @@
       "subtests": [
         {
           "name": "columnheader colindex 4",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -700,8 +700,8 @@
       "subtests": [
         {
           "name": "columnheader rowindex 4",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -712,8 +712,8 @@
       "subtests": [
         {
           "name": "columnheader selected false not automatically propagated",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is cell\" failed   \n**Actual value:** group  \n; \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -724,8 +724,8 @@
       "subtests": [
         {
           "name": "columnheader selected true not automatically propagated",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is cell\" failed   \n**Actual value:** group  \n; \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -754,7 +754,7 @@
         {
           "name": "combobox haspopup dialog",
           "status": "FAIL",
-          "message": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -766,7 +766,7 @@
         {
           "name": "combobox haspopup false",
           "status": "FAIL",
-          "message": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -778,7 +778,7 @@
         {
           "name": "combobox haspopup grid",
           "status": "FAIL",
-          "message": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -790,7 +790,7 @@
         {
           "name": "combobox haspopup listbox",
           "status": "FAIL",
-          "message": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -802,7 +802,7 @@
         {
           "name": "combobox haspopup menu",
           "status": "FAIL",
-          "message": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -814,7 +814,7 @@
         {
           "name": "combobox haspopup tree",
           "status": "FAIL",
-          "message": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -826,7 +826,7 @@
         {
           "name": "combobox haspopup true",
           "status": "FAIL",
-          "message": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -838,7 +838,7 @@
         {
           "name": "combobox haspopup unspecified",
           "status": "FAIL",
-          "message": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -849,8 +849,8 @@
       "subtests": [
         {
           "name": "combobox orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -861,8 +861,8 @@
       "subtests": [
         {
           "name": "combobox orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXOrientation is AXUnknownOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -873,8 +873,8 @@
       "subtests": [
         {
           "name": "combobox orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -885,8 +885,8 @@
       "subtests": [
         {
           "name": "combobox readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -897,8 +897,8 @@
       "subtests": [
         {
           "name": "combobox readonly true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -909,8 +909,8 @@
       "subtests": [
         {
           "name": "combobox readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -921,8 +921,8 @@
       "subtests": [
         {
           "name": "dialog modal false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** window  \n;  expected true got false"
         },
         {
           "name": "dialog modal false 1",
@@ -938,13 +938,13 @@
       "subtests": [
         {
           "name": "dialog modal true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** window  \n;  expected true got false"
         },
         {
           "name": "dialog modal true 1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -955,8 +955,8 @@
       "subtests": [
         {
           "name": "dialog modal unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** window  \n;  expected true got false"
         },
         {
           "name": "dialog modal unspecified 1",
@@ -972,8 +972,8 @@
       "subtests": [
         {
           "name": "div element without role roledescription valid",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is group\" failed   \n**Actual value:** foo  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -985,7 +985,7 @@
         {
           "name": "errormessage object in invalid state",
           "status": "FAIL",
-          "message": "assert_true: \"property TBD is TBD\" failed <https://webkit.org/b/165190>  \n;  expected true got false"
+          "message": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false"
         },
         {
           "name": "errormessage object in invalid state 1",
@@ -1002,7 +1002,7 @@
         {
           "name": "errormessage object in valid state",
           "status": "FAIL",
-          "message": "assert_true: \"property TBD is TBD\" failed <https://webkit.org/b/165190>  \n;  expected true got false"
+          "message": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false"
         },
         {
           "name": "errormessage object in valid state 1",
@@ -1018,8 +1018,8 @@
       "subtests": [
         {
           "name": "feed",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is feed\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1030,8 +1030,8 @@
       "subtests": [
         {
           "name": "figure",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXApplicationGroup  \n; \"property AXRoleDescription is figure\" failed   \n**Actual value:** group  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1042,18 +1042,18 @@
       "subtests": [
         {
           "name": "grid aria-readonly false automatically propagated",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         },
         {
           "name": "grid aria-readonly false automatically propagated 1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         },
         {
           "name": "grid aria-readonly false automatically propagated 2",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1064,8 +1064,8 @@
       "subtests": [
         {
           "name": "grid aria-readonly true automatically propagated",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
         },
         {
           "name": "grid aria-readonly true automatically propagated 1",
@@ -1086,8 +1086,8 @@
       "subtests": [
         {
           "name": "grid busy false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1098,8 +1098,8 @@
       "subtests": [
         {
           "name": "grid busy true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1110,8 +1110,8 @@
       "subtests": [
         {
           "name": "grid busy value changes",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is table\" failed   \n**Actual value:** None  \n; \"property AXElementBusy is true\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1122,8 +1122,8 @@
       "subtests": [
         {
           "name": "grid colcount 8",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1134,8 +1134,8 @@
       "subtests": [
         {
           "name": "grid columnheader readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1158,8 +1158,8 @@
       "subtests": [
         {
           "name": "grid columnheader readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1170,8 +1170,8 @@
       "subtests": [
         {
           "name": "grid columnheader required false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRequired is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1182,8 +1182,8 @@
       "subtests": [
         {
           "name": "grid columnheader required true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRequired is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1194,8 +1194,8 @@
       "subtests": [
         {
           "name": "grid columnheader required unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRequired is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1206,8 +1206,8 @@
       "subtests": [
         {
           "name": "grid rowcount 3",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIARowCount is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1218,8 +1218,8 @@
       "subtests": [
         {
           "name": "grid rowheader readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1242,8 +1242,8 @@
       "subtests": [
         {
           "name": "grid rowheader readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1254,8 +1254,8 @@
       "subtests": [
         {
           "name": "grid rowheader required false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRequired is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1266,8 +1266,8 @@
       "subtests": [
         {
           "name": "grid rowheader required true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRequired is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1278,8 +1278,8 @@
       "subtests": [
         {
           "name": "grid rowheader required unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRequired is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1290,8 +1290,8 @@
       "subtests": [
         {
           "name": "gridcell aria-colspan 2 on div",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1302,8 +1302,8 @@
       "subtests": [
         {
           "name": "gridcell aria-rowspan 2 on div",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1314,8 +1314,8 @@
       "subtests": [
         {
           "name": "gridcell colindex 4",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1326,8 +1326,8 @@
       "subtests": [
         {
           "name": "gridcell rowindex 4",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1350,8 +1350,8 @@
       "subtests": [
         {
           "name": "group hidden undefined element rendered",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1362,8 +1362,8 @@
       "subtests": [
         {
           "name": "heading level unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is heading\" failed   \n**Actual value:** AXHeading  \n; \"property AXValue is 2\" failed   \n**Actual value:** 0  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1375,7 +1375,7 @@
         {
           "name": "keyshortcuts multiple shortcuts",
           "status": "FAIL",
-          "message": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n<https://webkit.org/b/159215>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts  \n;  expected true got false"
+          "message": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1387,7 +1387,7 @@
         {
           "name": "keyshortcuts one shortcut",
           "status": "FAIL",
-          "message": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n<https://webkit.org/b/159215>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts  \n;  expected true got false"
+          "message": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1398,8 +1398,8 @@
       "subtests": [
         {
           "name": "listbox busy false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1410,8 +1410,8 @@
       "subtests": [
         {
           "name": "listbox busy true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1422,8 +1422,8 @@
       "subtests": [
         {
           "name": "listbox orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1434,8 +1434,8 @@
       "subtests": [
         {
           "name": "listbox orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1446,8 +1446,8 @@
       "subtests": [
         {
           "name": "listbox orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1458,8 +1458,8 @@
       "subtests": [
         {
           "name": "listbox readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1482,8 +1482,8 @@
       "subtests": [
         {
           "name": "listbox readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1494,8 +1494,8 @@
       "subtests": [
         {
           "name": "listitem setsize -1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIASetSize is -1\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1506,8 +1506,8 @@
       "subtests": [
         {
           "name": "menu orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1518,8 +1518,8 @@
       "subtests": [
         {
           "name": "menu orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1530,8 +1530,8 @@
       "subtests": [
         {
           "name": "menu orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1542,8 +1542,8 @@
       "subtests": [
         {
           "name": "menubar busy false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1554,8 +1554,8 @@
       "subtests": [
         {
           "name": "menubar busy true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1566,8 +1566,8 @@
       "subtests": [
         {
           "name": "menubar orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1578,8 +1578,8 @@
       "subtests": [
         {
           "name": "menubar orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1590,8 +1590,8 @@
       "subtests": [
         {
           "name": "menubar orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1602,8 +1602,8 @@
       "subtests": [
         {
           "name": "menuitem posinset and setsize",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1614,8 +1614,8 @@
       "subtests": [
         {
           "name": "menuitemcheckbox posinset and setsize",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXValue is 1\" failed   \n**Actual value:**   \n; \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1626,8 +1626,8 @@
       "subtests": [
         {
           "name": "menuitemcheckbox readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1650,8 +1650,8 @@
       "subtests": [
         {
           "name": "menuitemcheckbox readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1662,8 +1662,8 @@
       "subtests": [
         {
           "name": "menuitemradio posinset and setsize",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXValue is 0\" failed   \n**Actual value:**   \n; \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1674,8 +1674,8 @@
       "subtests": [
         {
           "name": "menuitemradio readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1698,8 +1698,8 @@
       "subtests": [
         {
           "name": "menuitemradio readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1722,8 +1722,8 @@
       "subtests": [
         {
           "name": "option selected false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1734,8 +1734,8 @@
       "subtests": [
         {
           "name": "option selected true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1746,8 +1746,8 @@
       "subtests": [
         {
           "name": "option selected undefined",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1780,8 +1780,8 @@
       "subtests": [
         {
           "name": "radiogroup orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1792,8 +1792,8 @@
       "subtests": [
         {
           "name": "radiogroup orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXUnknownOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1804,8 +1804,8 @@
       "subtests": [
         {
           "name": "radiogroup orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1816,8 +1816,8 @@
       "subtests": [
         {
           "name": "radiogroup readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1840,8 +1840,8 @@
       "subtests": [
         {
           "name": "radiogroup readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1852,8 +1852,8 @@
       "subtests": [
         {
           "name": "region with name",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** AXDocumentRegion  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1864,8 +1864,8 @@
       "subtests": [
         {
           "name": "region without name",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXDocumentRegion  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** region  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1881,8 +1881,8 @@
         },
         {
           "name": "row colindex 4 1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1898,8 +1898,8 @@
         },
         {
           "name": "row rowindex 4 1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1910,8 +1910,8 @@
       "subtests": [
         {
           "name": "rowheader aria-colspan 2 on div",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1922,8 +1922,8 @@
       "subtests": [
         {
           "name": "rowheader aria-rowspan 2 on div",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1934,8 +1934,8 @@
       "subtests": [
         {
           "name": "rowheader colindex 4",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1946,8 +1946,8 @@
       "subtests": [
         {
           "name": "rowheader rowindex 4",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1958,8 +1958,8 @@
       "subtests": [
         {
           "name": "rowheader selected false not automatically propagated",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is cell\" failed   \n**Actual value:** group  \n; \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1970,8 +1970,8 @@
       "subtests": [
         {
           "name": "rowheader selected true not automatically propagated",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is cell\" failed   \n**Actual value:** group  \n; \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1982,8 +1982,8 @@
       "subtests": [
         {
           "name": "scrollbar all values unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -1994,8 +1994,8 @@
       "subtests": [
         {
           "name": "scrollbar only valuenow unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 20\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 40\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2006,8 +2006,8 @@
       "subtests": [
         {
           "name": "scrollbar orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2018,8 +2018,8 @@
       "subtests": [
         {
           "name": "searchbox",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2031,12 +2031,12 @@
         {
           "name": "searchbox activedescendant",
           "status": "FAIL",
-          "message": "assert_true: \"property AXFocused is false\" failed   \n**Actual value:** true  \n;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         },
         {
           "name": "searchbox activedescendant 1",
           "status": "FAIL",
-          "message": "assert_true: \"property AXFocused is true\" failed   \n**Actual value:** false  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2048,12 +2048,12 @@
         {
           "name": "searchbox activedescendant value changes",
           "status": "FAIL",
-          "message": "assert_true: \"property AXFocused is false\" failed   \n**Actual value:** true  \n; \"result array isNot true\" failed   \n;  expected true got false"
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"event type is AXSelectedChildrenChanged\" failed   \n**Actual value:** false  \n; \"result array isNot true\" failed   \n;  expected true got false"
         },
         {
           "name": "searchbox activedescendant value changes 1",
           "status": "FAIL",
-          "message": "assert_true: \"property AXFocused is true\" failed   \n**Actual value:** false  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2064,8 +2064,8 @@
       "subtests": [
         {
           "name": "searchbox autocomplete both",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2076,8 +2076,8 @@
       "subtests": [
         {
           "name": "searchbox autocomplete inline",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2088,8 +2088,8 @@
       "subtests": [
         {
           "name": "searchbox autocomplete list",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2100,8 +2100,8 @@
       "subtests": [
         {
           "name": "searchbox autocomplete none",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2112,8 +2112,8 @@
       "subtests": [
         {
           "name": "searchbox autocomplete unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2124,8 +2124,8 @@
       "subtests": [
         {
           "name": "searchbox multiline false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2136,8 +2136,8 @@
       "subtests": [
         {
           "name": "searchbox multiline true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2148,8 +2148,8 @@
       "subtests": [
         {
           "name": "searchbox multiline unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2160,8 +2160,8 @@
       "subtests": [
         {
           "name": "searchbox placeholder",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"property AXPlaceholderValue is DD/MM/YYYY\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2172,8 +2172,8 @@
       "subtests": [
         {
           "name": "searchbox readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2184,8 +2184,8 @@
       "subtests": [
         {
           "name": "searchbox readonly true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"result AXUIElementIsAttributeSettable(AXValue) is false\" failed   \n**Actual value:** true  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2196,8 +2196,8 @@
       "subtests": [
         {
           "name": "searchbox readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2208,8 +2208,8 @@
       "subtests": [
         {
           "name": "searchbox required false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2220,8 +2220,8 @@
       "subtests": [
         {
           "name": "searchbox required true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2232,8 +2232,8 @@
       "subtests": [
         {
           "name": "searchbox required unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2244,8 +2244,8 @@
       "subtests": [
         {
           "name": "separator focusable all values unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n; \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2256,8 +2256,8 @@
       "subtests": [
         {
           "name": "separator focusable only valuenow unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n; \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2268,8 +2268,8 @@
       "subtests": [
         {
           "name": "separator focusable valuetext",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n; \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n; \"property AXValueDescription is Bonaire\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2280,8 +2280,8 @@
       "subtests": [
         {
           "name": "separator orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n; \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2292,8 +2292,8 @@
       "subtests": [
         {
           "name": "separator unfocusable all values unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2304,8 +2304,8 @@
       "subtests": [
         {
           "name": "separator unfocusable valuetext",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2316,8 +2316,8 @@
       "subtests": [
         {
           "name": "slider all values unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2328,8 +2328,8 @@
       "subtests": [
         {
           "name": "slider only valuenow unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 20\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 40\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2340,8 +2340,8 @@
       "subtests": [
         {
           "name": "slider orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2352,8 +2352,8 @@
       "subtests": [
         {
           "name": "slider readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2376,8 +2376,8 @@
       "subtests": [
         {
           "name": "slider readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2388,8 +2388,8 @@
       "subtests": [
         {
           "name": "spinbutton all values unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXMinValue isLTE -9007199254740992\" failed   \n**Actual value:** None  \n; \"property AXValue is 0\" failed   \n**Actual value:**   \n; \"property AXMaxValue isGTE 9007199254740992\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2400,8 +2400,8 @@
       "subtests": [
         {
           "name": "spinbutton only aria-valuenow unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 0\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2412,8 +2412,8 @@
       "subtests": [
         {
           "name": "spinbutton readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2436,8 +2436,8 @@
       "subtests": [
         {
           "name": "spinbutton readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2448,8 +2448,8 @@
       "subtests": [
         {
           "name": "switch checked false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXValue is 0\" failed   \n**Actual value:**   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2460,8 +2460,8 @@
       "subtests": [
         {
           "name": "switch checked mixed",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXValue is 0\" failed   \n**Actual value:**   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2472,8 +2472,8 @@
       "subtests": [
         {
           "name": "switch checked true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXValue is 1\" failed   \n**Actual value:**   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2484,8 +2484,8 @@
       "subtests": [
         {
           "name": "switch checked undefined",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXValue is 0\" failed   \n**Actual value:**   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2496,8 +2496,8 @@
       "subtests": [
         {
           "name": "switch checked value changes",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXRoleDescription is switch\" failed   \n**Actual value:**   \n; \"property AXValue is 1\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2508,8 +2508,8 @@
       "subtests": [
         {
           "name": "switch readonly false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2532,8 +2532,8 @@
       "subtests": [
         {
           "name": "switch readonly unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2544,8 +2544,8 @@
       "subtests": [
         {
           "name": "tab posinset and setsize",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAPosInSet is 3\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 7\" failed   \n**Actual value:** None  \n; \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2556,8 +2556,8 @@
       "subtests": [
         {
           "name": "table colcount -1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnCount is -1\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2568,8 +2568,8 @@
       "subtests": [
         {
           "name": "table colcount 8",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2580,8 +2580,8 @@
       "subtests": [
         {
           "name": "table rowcount -1",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIARowCount contains -1\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2592,8 +2592,8 @@
       "subtests": [
         {
           "name": "table rowcount 3",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIARowCount is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2604,8 +2604,8 @@
       "subtests": [
         {
           "name": "tablist orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2616,8 +2616,8 @@
       "subtests": [
         {
           "name": "tablist orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2628,8 +2628,8 @@
       "subtests": [
         {
           "name": "tablist orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2652,8 +2652,8 @@
       "subtests": [
         {
           "name": "textbox placeholder",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXPlaceholderValue is DD/MM/YYYY\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2664,8 +2664,8 @@
       "subtests": [
         {
           "name": "toolbar orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2676,8 +2676,8 @@
       "subtests": [
         {
           "name": "toolbar orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2688,8 +2688,8 @@
       "subtests": [
         {
           "name": "toolbar orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2700,8 +2700,8 @@
       "subtests": [
         {
           "name": "tree orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2712,8 +2712,8 @@
       "subtests": [
         {
           "name": "tree orientation unspecified",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2724,8 +2724,8 @@
       "subtests": [
         {
           "name": "tree orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2736,8 +2736,8 @@
       "subtests": [
         {
           "name": "treegrid colcount 8",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2748,8 +2748,8 @@
       "subtests": [
         {
           "name": "treegrid orientation horizontal",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2772,8 +2772,8 @@
       "subtests": [
         {
           "name": "treegrid orientation vertical",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2784,8 +2784,8 @@
       "subtests": [
         {
           "name": "treegrid rowcount 3",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXARIARowCount is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2796,8 +2796,8 @@
       "subtests": [
         {
           "name": "treeitem selected false",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2808,8 +2808,8 @@
       "subtests": [
         {
           "name": "treeitem selected true",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2820,8 +2820,8 @@
       "subtests": [
         {
           "name": "treeitem selected undefined",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",

--- a/wai-aria/GC02.json
+++ b/wai-aria/GC02.json
@@ -62,7 +62,7 @@
         {
           "name": "application activedescendant value changes 1",
           "status": "FAIL",
-          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -183,6 +183,11 @@
           "name": "aria-details pointing to details element",
           "status": "FAIL",
           "message": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false"
+        },
+        {
+          "name": "aria-details pointing to details element 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -195,6 +200,11 @@
           "name": "aria-details pointing to div element",
           "status": "FAIL",
           "message": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false"
+        },
+        {
+          "name": "aria-details pointing to div element 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -427,7 +437,7 @@
         {
           "name": "cell aria-colspan 2 on td html colspan 3",
           "status": "FAIL",
-          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
+          "message": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -726,8 +736,13 @@
       "subtests": [
         {
           "name": "combobox controls an invalid ID",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "combobox controls an invalid ID 1",
           "status": "FAIL",
-          "message": "assert_true: \"property AXLinkedUIElements doesNotContain myID\" failed   \n**Actual value:** None  \n;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -751,7 +766,7 @@
         {
           "name": "combobox haspopup false",
           "status": "FAIL",
-          "message": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+          "message": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -971,6 +986,11 @@
           "name": "errormessage object in invalid state",
           "status": "FAIL",
           "message": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false"
+        },
+        {
+          "name": "errormessage object in invalid state 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -983,6 +1003,11 @@
           "name": "errormessage object in valid state",
           "status": "FAIL",
           "message": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false"
+        },
+        {
+          "name": "errormessage object in valid state 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1469,8 +1494,8 @@
       "subtests": [
         {
           "name": "listitem setsize -1",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXARIASetSize is -1\" failed   \n**Actual value:** 1  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -1740,6 +1765,11 @@
           "name": "option selected value changes 1",
           "status": "FAIL",
           "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+        },
+        {
+          "name": "option selected value changes 2",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -2006,7 +2036,7 @@
         {
           "name": "searchbox activedescendant 1",
           "status": "FAIL",
-          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2023,7 +2053,7 @@
         {
           "name": "searchbox activedescendant value changes 1",
           "status": "FAIL",
-          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          "message": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2215,7 +2245,7 @@
         {
           "name": "separator focusable all values unspecified",
           "status": "FAIL",
-          "message": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
+          "message": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:** 0.0  \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2227,7 +2257,7 @@
         {
           "name": "separator focusable only valuenow unspecified",
           "status": "FAIL",
-          "message": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
+          "message": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2239,7 +2269,7 @@
         {
           "name": "separator focusable valuetext",
           "status": "FAIL",
-          "message": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n; \"property AXValueDescription is Bonaire\" failed   \n**Actual value:**   \n;  expected true got false"
+          "message": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:** 0.0  \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2466,8 +2496,8 @@
       "subtests": [
         {
           "name": "switch checked value changes",
-          "status": "PASS",
-          "message": null
+          "status": "FAIL",
+          "message": "assert_true: \"property AXValue is 1\" failed   \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2551,7 +2581,7 @@
         {
           "name": "table rowcount -1",
           "status": "FAIL",
-          "message": "assert_true: \"property AXARIARowCount is -1\" failed   \n**Actual value:** None  \n;  expected true got false"
+          "message": "assert_true: \"property AXARIARowCount contains -1\" failed   \n**Actual value:** None  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -2809,6 +2839,11 @@
           "name": "treeitem selected value changes 1",
           "status": "FAIL",
           "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+        },
+        {
+          "name": "treeitem selected value changes 2",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",

--- a/wai-aria/README.md
+++ b/wai-aria/README.md
@@ -12,7 +12,7 @@ List of supported AT APIs
 =========================
 
 01. ATK
-02. AXAPI
+02. AX API
 03. IAccessible2
 04. MSAA
 05. UIA
@@ -27,15 +27,19 @@ Index of implementations in reports
   * email: jdiggs@igalia.com
   * link: <http://www.mozilla.org>
 
+* FF02 - Firefox on macOS using AX API
+  * email: jdiggs@igalia.com
+  * link: <http://www.mozilla.org>
+
 * WK01 - WebKit on Linux using ATK
   * email: jdiggs@igalia.com
   * link: <https://webkitgtk.org>
 
-* WK02 - WebKit on OS X using AXAPI
+* WK02 - WebKit/Safari on macOS using AX API
   * email: jdiggs@igalia.com
   * link: <https://webkit.org>
 
-* GC02 - Chrome on OS X using AXAPI
+* GC02 - Chrome on macOS using AX API
   * email: jdiggs@igalia.com
   * link: <https://www.google.com/chrome/>
 

--- a/wai-aria/WK01.json
+++ b/wai-aria/WK01.json
@@ -7,6 +7,11 @@
           "name": "alertdialog modal false",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "alertdialog modal false 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -19,6 +24,11 @@
           "name": "alertdialog modal true",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "alertdialog modal true 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -172,12 +182,12 @@
         {
           "name": "aria-details pointing to details element",
           "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_DETAILS is details\" failed   \n**Actual value:** None  \nERROR: Object not found  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types  \n;  expected true got false"
+          "message": "assert\\_true: \"relation RELATION\\_DETAILS is [details]\" failed   \n**Actual value:** None  \nERROR: Object not found  \n;  expected true got false"
         },
         {
           "name": "aria-details pointing to details element 1",
           "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types  \n;  expected true got false"
+          "message": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -189,12 +199,12 @@
         {
           "name": "aria-details pointing to div element",
           "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_DETAILS is details\" failed   \n**Actual value:** None  \nERROR: Object not found  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types  \n;  expected true got false"
+          "message": "assert\\_true: \"relation RELATION\\_DETAILS is [details]\" failed   \n**Actual value:** None  \nERROR: Object not found  \n;  expected true got false"
         },
         {
           "name": "aria-details pointing to div element 1",
           "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types  \n;  expected true got false"
+          "message": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -913,6 +923,11 @@
           "name": "dialog modal false",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "dialog modal false 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -925,6 +940,11 @@
           "name": "dialog modal true",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "dialog modal true 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -937,6 +957,11 @@
           "name": "dialog modal unspecified",
           "status": "PASS",
           "message": null
+        },
+        {
+          "name": "dialog modal unspecified 1",
+          "status": "FAIL",
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -960,12 +985,12 @@
         {
           "name": "errormessage object in invalid state",
           "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE exists false\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types  \n;  expected true got false"
+          "message": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE is [error]\" failed   \n**Actual value:** []  \n;  expected true got false"
         },
         {
           "name": "errormessage object in invalid state 1",
           "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_ERROR_FOR exists false\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types  \n;  expected true got false"
+          "message": "assert\\_true: \"relation RELATION\\_ERROR_FOR is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
         }
       ],
       "status": "OK",
@@ -976,13 +1001,13 @@
       "subtests": [
         {
           "name": "errormessage object in valid state",
-          "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE is error\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         },
         {
           "name": "errormessage object in valid state 1",
-          "status": "FAIL",
-          "message": "assert\\_true: \"relation RELATION\\_ERROR_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -2615,8 +2640,8 @@
       "subtests": [
         {
           "name": "term role",
-          "status": "FAIL",
-          "message": "assert\\_true: \"property role is ROLE_DESCRIPTION_TERM\" failed   \n**Actual value:** ROLE\\_UNKNOWN  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 is missing roles that are present in ATK  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",

--- a/wai-aria/all.html
+++ b/wai-aria/all.html
@@ -243,28 +243,46 @@
 <li><a href='#test-file-226'>/wai-aria/treeitem_selected_value_changes-manual.html</a></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/wai-aria/alertdialog_modal_false-manual.html' target='_blank'>/wai-aria/alertdialog_modal_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-0-0' class='subtest'><td>alertdialog modal false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web alert dialog" failed <br />
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>FF02</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/wai-aria/alertdialog_modal_false-manual.html' target='_blank'>/wai-aria/alertdialog_modal_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-0-0' class='subtest'><td>alertdialog modal false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXGroup" failed <br />
+<strong>Actual value:</strong> AXWindow <br />
+; "property AXRoleDescription is web alert dialog" failed <br />
+<strong>Actual value:</strong> alert dialog <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web alert dialog" failed <br />
 <strong>Actual value:</strong> alertdialog <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-0-1' class='subtest'><td>alertdialog modal false 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/wai-aria/alertdialog_modal_true-manual.html' target='_blank'>/wai-aria/alertdialog_modal_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-1-0' class='subtest'><td>alertdialog modal true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web alert dialog" failed <br />
+<tr id='subtest-0-1' class='subtest'><td>alertdialog modal false 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/wai-aria/alertdialog_modal_true-manual.html' target='_blank'>/wai-aria/alertdialog_modal_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-1-0' class='subtest'><td>alertdialog modal true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXGroup" failed <br />
+<strong>Actual value:</strong> AXWindow <br />
+; "property AXRoleDescription is web alert dialog" failed <br />
+<strong>Actual value:</strong> alert dialog <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web alert dialog" failed <br />
 <strong>Actual value:</strong> alertdialog <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-1-1' class='subtest'><td>alertdialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
+<tr id='subtest-1-1' class='subtest'><td>alertdialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property accessible is false" failed <br />
+<strong>Actual value:</strong> true <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant-manual.html' target='_blank'>/wai-aria/application_activedescendant-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-2-0' class='subtest'><td>application activedescendant</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant-manual.html' target='_blank'>/wai-aria/application_activedescendant-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-2-0' class='subtest'><td>application activedescendant</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is web application" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
 <strong>Actual value:</strong> AXLandmarkApplication <br />
 ; "property AXRoleDescription is web application" failed <br />
 <strong>Actual value:</strong> application <br />
@@ -276,12 +294,13 @@
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-2-1' class='subtest'><td>application activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr id='subtest-2-1' class='subtest'><td>application activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
@@ -297,9 +316,17 @@
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/application_activedescendant_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-3-0' class='subtest'><td>application activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/application_activedescendant_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-3-0' class='subtest'><td>application activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is web application" failed <br />
+<strong>Actual value:</strong> group <br />
+; "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXSelectedChildrenChanged" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
 <strong>Actual value:</strong> AXLandmarkApplication <br />
 ; "property AXRoleDescription is web application" failed <br />
 <strong>Actual value:</strong> application <br />
@@ -313,16 +340,18 @@
 ; "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-3-1' class='subtest'><td>application activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr id='subtest-3-1' class='subtest'><td>application activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
@@ -337,143 +366,159 @@
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_not_declared-manual.html' target='_blank'>/wai-aria/aria-current_not_declared-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-4-0' class='subtest'><td>aria-current not declared</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is false" failed <br />
+<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_not_declared-manual.html' target='_blank'>/wai-aria/aria-current_not_declared-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-4-0' class='subtest'><td>aria-current not declared</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIACurrent is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is false" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_changes-manual.html' target='_blank'>/wai-aria/aria-current_with_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-5-0' class='subtest'><td>aria-current with value changes</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:state-changed:active" failed <a href="https://bugzil.la/1355921">https://bugzil.la/1355921</a> <br />
+<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_changes-manual.html' target='_blank'>/wai-aria/aria-current_with_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-5-0' class='subtest'><td>aria-current with value changes</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:state-changed:active" failed <a href="https://bugzil.la/1355921">https://bugzil.la/1355921</a> <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIACurrent contains false" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent contains false" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_date-manual.html' target='_blank'>/wai-aria/aria-current_with_value_date-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-6-0' class='subtest'><td>aria-current with value date</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
+<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_date-manual.html' target='_blank'>/wai-aria/aria-current_with_value_date-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-6-0' class='subtest'><td>aria-current with value date</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SELECTABLE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355921">https://bugzil.la/1355921</a>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK_STATE_ACTIVE <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXARIACurrent is date" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is date" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_location-manual.html' target='_blank'>/wai-aria/aria-current_with_value_location-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-7-0' class='subtest'><td>aria-current with value location</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
+<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_location-manual.html' target='_blank'>/wai-aria/aria-current_with_value_location-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-7-0' class='subtest'><td>aria-current with value location</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355921">https://bugzil.la/1355921</a>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK_STATE_ACTIVE <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIACurrent is location" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is location" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_page-manual.html' target='_blank'>/wai-aria/aria-current_with_value_page-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-8-0' class='subtest'><td>aria-current with value page</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
+<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_page-manual.html' target='_blank'>/wai-aria/aria-current_with_value_page-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-8-0' class='subtest'><td>aria-current with value page</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355921">https://bugzil.la/1355921</a>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK_STATE_ACTIVE <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIACurrent is page" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is page" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_step-manual.html' target='_blank'>/wai-aria/aria-current_with_value_step-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-9-0' class='subtest'><td>aria-current with value step</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
+<tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_step-manual.html' target='_blank'>/wai-aria/aria-current_with_value_step-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-9-0' class='subtest'><td>aria-current with value step</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355921">https://bugzil.la/1355921</a>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK_STATE_ACTIVE <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIACurrent is step" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is step" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_time-manual.html' target='_blank'>/wai-aria/aria-current_with_value_time-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-10-0' class='subtest'><td>aria-current with value time</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
+<tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_time-manual.html' target='_blank'>/wai-aria/aria-current_with_value_time-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-10-0' class='subtest'><td>aria-current with value time</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SELECTABLE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355921">https://bugzil.la/1355921</a>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK_STATE_ACTIVE <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXARIACurrent is time" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is time" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_true-manual.html' target='_blank'>/wai-aria/aria-current_with_value_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-11-0' class='subtest'><td>aria-current with value true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
+<tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_true-manual.html' target='_blank'>/wai-aria/aria-current_with_value_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-11-0' class='subtest'><td>aria-current with value true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_ACTIVE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1355921">https://bugzil.la/1355921</a>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK_STATE_ACTIVE <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIACurrent is true" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_unspecified-manual.html' target='_blank'>/wai-aria/aria-current_with_value_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-12-0' class='subtest'><td>aria-current with value unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is false" failed <br />
+<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/wai-aria/aria-current_with_value_unspecified-manual.html' target='_blank'>/wai-aria/aria-current_with_value_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-12-0' class='subtest'><td>aria-current with value unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIACurrent is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIACurrent is false" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-13-0' class='subtest'><td>aria-details pointing to details element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-13-0' class='subtest'><td>aria-details pointing to details element</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is [details]" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: Object not found <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165842">https://webkit.org/b/165842</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-13-1' class='subtest'><td>aria-details pointing to details element 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
+<tr id='subtest-13-1' class='subtest'><td>aria-details pointing to details element 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-14-0' class='subtest'><td>aria-details pointing to div element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-14-0' class='subtest'><td>aria-details pointing to div element</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is [details]" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: Object not found <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165842">https://webkit.org/b/165842</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-14-1' class='subtest'><td>aria-details pointing to div element 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
+<tr id='subtest-14-1' class='subtest'><td>aria-details pointing to div element 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/wai-aria/article_in_feed_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/article_in_feed_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-15-0' class='subtest'><td>article in feed posinset and setsize</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_ARTICLE" failed <br />
-<strong>Actual value:</strong> ROLE_DOCUMENT_FRAME <br />
-<a href="https://bugzil.la/1305446">https://bugzil.la/1305446</a>: [NEW] Expose ARIA "article" role as ROLE_ARTICLE and "log" role as ROLE_LOG <br />
+<tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/wai-aria/article_in_feed_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/article_in_feed_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-15-0' class='subtest'><td>article in feed posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXARIASetSize is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
 <strong>Actual value:</strong> 0 <br />
@@ -481,24 +526,25 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> 0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/wai-aria/article_in_feed_setsize_-1-manual.html' target='_blank'>/wai-aria/article_in_feed_setsize_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-16-0' class='subtest'><td>article in feed setsize -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_ARTICLE" failed <br />
-<strong>Actual value:</strong> ROLE_DOCUMENT_FRAME <br />
-<a href="https://bugzil.la/1305446">https://bugzil.la/1305446</a>: [NEW] Expose ARIA "article" role as ROLE_ARTICLE and "log" role as ROLE_LOG <br />
-; "property objectAttributes contains setsize:-1" failed <br />
+<tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/wai-aria/article_in_feed_setsize_-1-manual.html' target='_blank'>/wai-aria/article_in_feed_setsize_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-16-0' class='subtest'><td>article in feed setsize -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains setsize:-1" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:article', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1358473">https://bugzil.la/1358473</a>: [NEW] Do not calculate setsize when aria-setsize has a value of -1 <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIASetSize is -1" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIASetSize is -1" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/wai-aria/article_not_in_feed_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/article_not_in_feed_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-17-0' class='subtest'><td>article not in feed posinset and setsize</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_ARTICLE" failed <br />
-<strong>Actual value:</strong> ROLE_DOCUMENT_FRAME <br />
-<a href="https://bugzil.la/1305446">https://bugzil.la/1305446</a>: [NEW] Expose ARIA "article" role as ROLE_ARTICLE and "log" role as ROLE_LOG <br />
+<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/wai-aria/article_not_in_feed_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/article_not_in_feed_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-17-0' class='subtest'><td>article not in feed posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXARIASetSize is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
 <strong>Actual value:</strong> 0 <br />
@@ -506,14 +552,20 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> 0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_dialog-manual.html' target='_blank'>/wai-aria/button_haspopup_dialog-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-18-0' class='subtest'><td>button haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:dialog" failed <br />
+<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_dialog-manual.html' target='_blank'>/wai-aria/button_haspopup_dialog-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-18-0' class='subtest'><td>button haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:dialog" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
-; "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
 <strong>Actual value:</strong> AXButton <br />
@@ -521,81 +573,17 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> button <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_emptystring-manual.html' target='_blank'>/wai-aria/button_haspopup_emptystring-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-19-0' class='subtest'><td>button haspopup emptystring</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:false" failed <br />
+<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_emptystring-manual.html' target='_blank'>/wai-aria/button_haspopup_emptystring-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-19-0' class='subtest'><td>button haspopup emptystring</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:false" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property actions doesNotContain AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
-    AXPress, <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
+    AXPress <br />
 ) <br />
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-; "property actions doesNotContain AXPress" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXPress, <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXPress, <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-; "property actions doesNotContain AXPress" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXPress, <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_false-manual.html' target='_blank'>/wai-aria/button_haspopup_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-20-0' class='subtest'><td>button haspopup false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXPress, <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-; "property actions doesNotContain AXPress" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXPress, <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXPress, <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-; "property actions doesNotContain AXPress" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXPress, <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_foo-manual.html' target='_blank'>/wai-aria/button_haspopup_foo-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-21-0' class='subtest'><td>button haspopup foo</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:false" failed <br />
-<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
-<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
 <strong>Actual value:</strong> ( <br />
@@ -628,76 +616,15 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-22'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_grid-manual.html' target='_blank'>/wai-aria/button_haspopup_grid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-22-0' class='subtest'><td>button haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:grid" failed <br />
-<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
-<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
-; "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
+<tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_false-manual.html' target='_blank'>/wai-aria/button_haspopup_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-20-0' class='subtest'><td>button haspopup false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
-<strong>Actual value:</strong> AXButton <br />
-; "property AXRoleDescription is pop up button" failed <br />
-<strong>Actual value:</strong> button <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_listbox-manual.html' target='_blank'>/wai-aria/button_haspopup_listbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-23-0' class='subtest'><td>button haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:listbox" failed <br />
-<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
-<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
-; "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
-<strong>Actual value:</strong> AXButton <br />
-; "property AXRoleDescription is pop up button" failed <br />
-<strong>Actual value:</strong> button <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_menu-manual.html' target='_blank'>/wai-aria/button_haspopup_menu-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-24-0' class='subtest'><td>button haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:menu" failed <br />
-<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
-<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
-; "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
-<strong>Actual value:</strong> AXButton <br />
-; "property AXRoleDescription is pop up button" failed <br />
-<strong>Actual value:</strong> button <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_tree-manual.html' target='_blank'>/wai-aria/button_haspopup_tree-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-25-0' class='subtest'><td>button haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:tree" failed <br />
-<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
-<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
-; "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
-<strong>Actual value:</strong> AXButton <br />
-; "property AXRoleDescription is pop up button" failed <br />
-<strong>Actual value:</strong> button <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-26'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_true-manual.html' target='_blank'>/wai-aria/button_haspopup_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-26-0' class='subtest'><td>button haspopup true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/button_haspopup_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-27-0' class='subtest'><td>button haspopup unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXPress, <br />
     AXShowMenu, <br />
@@ -728,25 +655,212 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/wai-aria/button_roledescription_empty-manual.html' target='_blank'>/wai-aria/button_roledescription_empty-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-28-0' class='subtest'><td>button roledescription empty</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is button" failed <br />
+<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_foo-manual.html' target='_blank'>/wai-aria/button_haspopup_foo-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-21-0' class='subtest'><td>button haspopup foo</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:false" failed <br />
+<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
+<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
+; "property states doesNotContain STATE_HAS_POPUP" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_HAS_POPUP'] <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress, <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+; "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress, <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress, <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+; "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress, <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-22'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_grid-manual.html' target='_blank'>/wai-aria/button_haspopup_grid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-22-0' class='subtest'><td>button haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:grid" failed <br />
+<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
+<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_listbox-manual.html' target='_blank'>/wai-aria/button_haspopup_listbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-23-0' class='subtest'><td>button haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:listbox" failed <br />
+<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
+<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_menu-manual.html' target='_blank'>/wai-aria/button_haspopup_menu-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-24-0' class='subtest'><td>button haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:menu" failed <br />
+<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
+<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_tree-manual.html' target='_blank'>/wai-aria/button_haspopup_tree-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-25-0' class='subtest'><td>button haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:tree" failed <br />
+<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
+<a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> button <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-26'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_true-manual.html' target='_blank'>/wai-aria/button_haspopup_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-26-0' class='subtest'><td>button haspopup true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXPopUpButton" failed <br />
+<strong>Actual value:</strong> AXMenuButton <br />
+; "property AXRoleDescription is pop up button" failed <br />
+<strong>Actual value:</strong> menu button <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> [] <br />
+; "property actions contains AXPress" failed <br />
+<strong>Actual value:</strong> [] <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/button_haspopup_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-27-0' class='subtest'><td>button haspopup unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress, <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+; "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress, <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress, <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+; "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress, <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/wai-aria/button_roledescription_empty-manual.html' target='_blank'>/wai-aria/button_roledescription_empty-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-28-0' class='subtest'><td>button roledescription empty</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is button" failed <br />
 <strong>Actual value:</strong> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-29'><td><a href='http://www.w3c-test.org/wai-aria/button_roledescription_valid-manual.html' target='_blank'>/wai-aria/button_roledescription_valid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-29-0' class='subtest'><td>button roledescription valid</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-30'><td><a href='http://www.w3c-test.org/wai-aria/button_roledescription_whitespace_only-manual.html' target='_blank'>/wai-aria/button_roledescription_whitespace_only-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-30-0' class='subtest'><td>button roledescription whitespace only</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is button" failed <br />
+<tr class='test' id='test-file-29'><td><a href='http://www.w3c-test.org/wai-aria/button_roledescription_valid-manual.html' target='_blank'>/wai-aria/button_roledescription_valid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-29-0' class='subtest'><td>button roledescription valid</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is SassyButton" failed <br />
+<strong>Actual value:</strong> button <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-30'><td><a href='http://www.w3c-test.org/wai-aria/button_roledescription_whitespace_only-manual.html' target='_blank'>/wai-aria/button_roledescription_whitespace_only-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-30-0' class='subtest'><td>button roledescription whitespace only</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is button" failed <br />
 <strong>Actual value:</strong> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/wai-aria/cell-manual.html' target='_blank'>/wai-aria/cell-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-31-0' class='subtest'><td>cell</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
+<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/wai-aria/cell-manual.html' target='_blank'>/wai-aria/cell-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-31-0' class='subtest'><td>cell</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -756,10 +870,13 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-31-1' class='subtest'><td>cell 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr id='subtest-31-1' class='subtest'><td>cell 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -769,21 +886,43 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-32'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-32-0' class='subtest'><td>cell aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
+<tr class='test' id='test-file-32'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-32-0' class='subtest'><td>cell aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-33-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
+<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-33-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
 <strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'table-cell-index:0', 'tag:td', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px', 'colspan:2'] <br />
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-34-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3 with headers and border</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
+<strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'table-cell-index:3', 'tag:td', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px', 'colspan:2'] <br />
+<a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-35-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3 with three actual columns</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
 <strong>Actual value:</strong> AXGroup <br />
@@ -791,26 +930,16 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-34-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3 with headers and border</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
-<strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'table-cell-index:3', 'tag:td', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px', 'colspan:2'] <br />
-<a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-35-0' class='subtest'><td>cell aria-colspan 2 on td html colspan 3 with three actual columns</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
-<strong>Actual value:</strong> AXGroup <br />
-; "property AXColumnIndexRange.length is 3" failed <br />
-<strong>Actual value:</strong> None <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-36-0' class='subtest'><td>cell aria-colspan 2 on td with html colspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
+<tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html' target='_blank'>/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-36-0' class='subtest'><td>cell aria-colspan 2 on td with html colspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXColumnIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
 <strong>Actual value:</strong> AXGroup <br />
@@ -818,48 +947,65 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-37-0' class='subtest'><td>cell aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
+<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-37-0' class='subtest'><td>cell aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-38-0' class='subtest'><td>cell aria-rowspan 2 on td html rowspan 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain rowspan:2" failed <br />
+<tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-38-0' class='subtest'><td>cell aria-rowspan 2 on td html rowspan 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain rowspan:2" failed <br />
 <strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:cell', 'table-cell-index:0', 'tag:td', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-39'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-39-0' class='subtest'><td>cell aria-rowspan 2 on td html rowspan 3 with three actual rows</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=3" failed <br />
+<tr class='test' id='test-file-39'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-39-0' class='subtest'><td>cell aria-rowspan 2 on td html rowspan 3 with three actual rows</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=3" failed <br />
 <strong>Actual value:</strong> (row=1, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 3" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-40'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-40-0' class='subtest'><td>cell aria-rowspan 2 on td with html rowspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
+<tr class='test' id='test-file-40'><td><a href='http://www.w3c-test.org/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html' target='_blank'>/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-40-0' class='subtest'><td>cell aria-rowspan 2 on td with html rowspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRowIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/wai-aria/cell_colindex_4-manual.html' target='_blank'>/wai-aria/cell_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-41-0' class='subtest'><td>cell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/wai-aria/cell_colindex_4-manual.html' target='_blank'>/wai-aria/cell_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-41-0' class='subtest'><td>cell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -869,11 +1015,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/wai-aria/cell_rowindex_4-manual.html' target='_blank'>/wai-aria/cell_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-42-0' class='subtest'><td>cell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/wai-aria/cell_rowindex_4-manual.html' target='_blank'>/wai-aria/cell_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-42-0' class='subtest'><td>cell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -883,15 +1032,18 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_false-manual.html' target='_blank'>/wai-aria/checkbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-43-0' class='subtest'><td>checkbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_false-manual.html' target='_blank'>/wai-aria/checkbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-43-0' class='subtest'><td>checkbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-44'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_true-manual.html' target='_blank'>/wai-aria/checkbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-44-0' class='subtest'><td>checkbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKABLE" failed <br />
+<tr class='test' id='test-file-44'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_true-manual.html' target='_blank'>/wai-aria/checkbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-44-0' class='subtest'><td>checkbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ; "property states contains STATE_READ_ONLY" failed <br />
@@ -899,65 +1051,77 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/checkbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-45-0' class='subtest'><td>checkbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/wai-aria/checkbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/checkbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-45-0' class='subtest'><td>checkbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-46'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-46-0' class='subtest'><td>columnheader aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
+<tr class='test' id='test-file-46'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-46-0' class='subtest'><td>columnheader aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-47'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-47-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
+<tr class='test' id='test-file-47'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-47-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain colspan:2" failed <br />
 <strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'text-indent:0px', 'text-align:center', 'margin-left:0px', 'colspan:2'] <br />
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-48'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-48-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3 with three actual columns</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
+<tr class='test' id='test-file-48'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-48-0' class='subtest'><td>columnheader aria-colspan 2 on th html colspan 3 with three actual columns</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 3" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-49'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-49-0' class='subtest'><td>columnheader aria-colspan 2 on th with html colspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
+<tr class='test' id='test-file-49'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html' target='_blank'>/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-49-0' class='subtest'><td>columnheader aria-colspan 2 on th with html colspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-50'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-50-0' class='subtest'><td>columnheader aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
+<tr class='test' id='test-file-50'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-50-0' class='subtest'><td>columnheader aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-51'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-51-0' class='subtest'><td>columnheader aria-rowspan 2 on th html rowspan 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain rowspan:2" failed <br />
+<tr class='test' id='test-file-51'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-51-0' class='subtest'><td>columnheader aria-rowspan 2 on th html rowspan 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes doesNotContain rowspan:2" failed <br />
 <strong>Actual value:</strong> ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:columnheader', 'table-cell-index:0', 'tag:th', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:center', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1357153">https://bugzil.la/1357153</a>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-52-0' class='subtest'><td>columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=3" failed <br />
+<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-52-0' class='subtest'><td>columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=3" failed <br />
 <strong>Actual value:</strong> (row=1, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
 ;  expected true got false</td></tr>
@@ -965,21 +1129,27 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-53'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-53-0' class='subtest'><td>columnheader aria-rowspan 2 on th with html rowspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
+<tr class='test' id='test-file-53'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html' target='_blank'>/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-53-0' class='subtest'><td>columnheader aria-rowspan 2 on th with html rowspan not specified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_colindex_4-manual.html' target='_blank'>/wai-aria/columnheader_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-54-0' class='subtest'><td>columnheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_colindex_4-manual.html' target='_blank'>/wai-aria/columnheader_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-54-0' class='subtest'><td>columnheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -989,11 +1159,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_rowindex_4-manual.html' target='_blank'>/wai-aria/columnheader_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-55-0' class='subtest'><td>columnheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_rowindex_4-manual.html' target='_blank'>/wai-aria/columnheader_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-55-0' class='subtest'><td>columnheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -1003,29 +1176,48 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-56'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-56-0' class='subtest'><td>columnheader selected false not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
+<tr class='test' id='test-file-56'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-56-0' class='subtest'><td>columnheader selected false not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is cell" failed <br />
+<strong>Actual value:</strong> group <br />
+; "property AXSelected is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-57'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-57-0' class='subtest'><td>columnheader selected true not automatically propagated</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-58'><td><a href='http://www.w3c-test.org/wai-aria/combobox_controls_an_invalid_id-manual.html' target='_blank'>/wai-aria/combobox_controls_an_invalid_id-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-58-0' class='subtest'><td>combobox controls an invalid ID</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXLinkedUIElements doesNotContain myID" failed <br />
+<tr class='test' id='test-file-57'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-57-0' class='subtest'><td>columnheader selected true not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is cell" failed <br />
+<strong>Actual value:</strong> group <br />
+; "property AXSelected is false" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-58-1' class='subtest'><td>combobox controls an invalid ID 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_dialog-manual.html' target='_blank'>/wai-aria/combobox_haspopup_dialog-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-59-0' class='subtest'><td>combobox haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:dialog" failed <br />
+<tr class='test' id='test-file-58'><td><a href='http://www.w3c-test.org/wai-aria/combobox_controls_an_invalid_id-manual.html' target='_blank'>/wai-aria/combobox_controls_an_invalid_id-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-58-0' class='subtest'><td>combobox controls an invalid ID</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-58-1' class='subtest'><td>combobox controls an invalid ID 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_dialog-manual.html' target='_blank'>/wai-aria/combobox_haspopup_dialog-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-59-0' class='subtest'><td>combobox haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:dialog" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
@@ -1041,15 +1233,24 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-60'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_false-manual.html' target='_blank'>/wai-aria/combobox_haspopup_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-60-0' class='subtest'><td>combobox haspopup false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<tr class='test' id='test-file-60'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_false-manual.html' target='_blank'>/wai-aria/combobox_haspopup_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-60-0' class='subtest'><td>combobox haspopup false</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_HAS_POPUP" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_HAS_POPUP'] <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions doesNotContain AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
+    AXPress <br />
 ) <br />
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-; "property actions doesNotContain AXPress" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
     AXScrollToVisible <br />
@@ -1062,23 +1263,25 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
     AXScrollToVisible <br />
 ) <br />
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-; "property actions doesNotContain AXPress" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-61'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_grid-manual.html' target='_blank'>/wai-aria/combobox_haspopup_grid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-61-0' class='subtest'><td>combobox haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:grid" failed <br />
+<tr class='test' id='test-file-61'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_grid-manual.html' target='_blank'>/wai-aria/combobox_haspopup_grid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-61-0' class='subtest'><td>combobox haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:grid" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -1093,15 +1296,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_listbox-manual.html' target='_blank'>/wai-aria/combobox_haspopup_listbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-62-0' class='subtest'><td>combobox haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:listbox" failed <br />
+<tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_listbox-manual.html' target='_blank'>/wai-aria/combobox_haspopup_listbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-62-0' class='subtest'><td>combobox haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:listbox" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -1116,15 +1327,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-63'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_menu-manual.html' target='_blank'>/wai-aria/combobox_haspopup_menu-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-63-0' class='subtest'><td>combobox haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:menu" failed <br />
+<tr class='test' id='test-file-63'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_menu-manual.html' target='_blank'>/wai-aria/combobox_haspopup_menu-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-63-0' class='subtest'><td>combobox haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:menu" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -1139,15 +1358,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-64'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_tree-manual.html' target='_blank'>/wai-aria/combobox_haspopup_tree-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-64-0' class='subtest'><td>combobox haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:tree" failed <br />
+<tr class='test' id='test-file-64'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_tree-manual.html' target='_blank'>/wai-aria/combobox_haspopup_tree-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-64-0' class='subtest'><td>combobox haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:tree" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -1162,11 +1389,18 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-65'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_true-manual.html' target='_blank'>/wai-aria/combobox_haspopup_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-65-0' class='subtest'><td>combobox haspopup true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
+<tr class='test' id='test-file-65'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_true-manual.html' target='_blank'>/wai-aria/combobox_haspopup_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-65-0' class='subtest'><td>combobox haspopup true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
@@ -1182,15 +1416,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-66'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/combobox_haspopup_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-66-0' class='subtest'><td>combobox haspopup unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:listbox" failed <br />
-<strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
+<tr class='test' id='test-file-66'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/combobox_haspopup_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-66-0' class='subtest'><td>combobox haspopup unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:listbox" failed <br />
+<strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -1205,131 +1447,165 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-67'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_horizontal-manual.html' target='_blank'>/wai-aria/combobox_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-67-0' class='subtest'><td>combobox orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-68'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_unspecified-manual.html' target='_blank'>/wai-aria/combobox_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-68-0' class='subtest'><td>combobox orientation unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_VERTICAL" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1357042">https://bugzil.la/1357042</a>: [NEW] Implement or update support for exposure of aria-orientation via ATK StateSet <br />
+<tr class='test' id='test-file-67'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_horizontal-manual.html' target='_blank'>/wai-aria/combobox_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-67-0' class='subtest'><td>combobox orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-68'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_unspecified-manual.html' target='_blank'>/wai-aria/combobox_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-68-0' class='subtest'><td>combobox orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXOrientation is AXUnknownOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXOrientation is AXUnknownOrientation" failed <br />
 <strong>Actual value:</strong> AXVerticalOrientation <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-69'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_vertical-manual.html' target='_blank'>/wai-aria/combobox_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-69-0' class='subtest'><td>combobox orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-70'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_false-manual.html' target='_blank'>/wai-aria/combobox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-70-0' class='subtest'><td>combobox readonly false</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
+<tr class='test' id='test-file-69'><td><a href='http://www.w3c-test.org/wai-aria/combobox_orientation_vertical-manual.html' target='_blank'>/wai-aria/combobox_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-69-0' class='subtest'><td>combobox orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-71'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_true-manual.html' target='_blank'>/wai-aria/combobox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-71-0' class='subtest'><td>combobox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS<em>POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property states contains STATE_READ</em>ONLY" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr class='test' id='test-file-70'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_false-manual.html' target='_blank'>/wai-aria/combobox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-70-0' class='subtest'><td>combobox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-71'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_true-manual.html' target='_blank'>/wai-aria/combobox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-71-0' class='subtest'><td>combobox readonly true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_HAS_POPUP'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-72'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/combobox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-72-0' class='subtest'><td>combobox readonly unspecified</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-73'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_false-manual.html' target='_blank'>/wai-aria/dialog_modal_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-73-0' class='subtest'><td>dialog modal false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
+<tr class='test' id='test-file-72'><td><a href='http://www.w3c-test.org/wai-aria/combobox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/combobox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-72-0' class='subtest'><td>combobox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-73'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_false-manual.html' target='_blank'>/wai-aria/dialog_modal_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-73-0' class='subtest'><td>dialog modal false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXGroup" failed <br />
+<strong>Actual value:</strong> AXWindow <br />
+; "property AXRoleDescription is web dialog" failed <br />
+<strong>Actual value:</strong> window <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
 <strong>Actual value:</strong> dialog <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-73-1' class='subtest'><td>dialog modal false 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_true-manual.html' target='_blank'>/wai-aria/dialog_modal_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-74-0' class='subtest'><td>dialog modal true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
+<tr id='subtest-73-1' class='subtest'><td>dialog modal false 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_true-manual.html' target='_blank'>/wai-aria/dialog_modal_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-74-0' class='subtest'><td>dialog modal true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXGroup" failed <br />
+<strong>Actual value:</strong> AXWindow <br />
+; "property AXRoleDescription is web dialog" failed <br />
+<strong>Actual value:</strong> window <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
 <strong>Actual value:</strong> dialog <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-74-1' class='subtest'><td>dialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
+<tr id='subtest-74-1' class='subtest'><td>dialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property accessible is false" failed <br />
+<strong>Actual value:</strong> true <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-75'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_unspecified-manual.html' target='_blank'>/wai-aria/dialog_modal_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-75-0' class='subtest'><td>dialog modal unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
+<tr class='test' id='test-file-75'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_unspecified-manual.html' target='_blank'>/wai-aria/dialog_modal_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-75-0' class='subtest'><td>dialog modal unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXGroup" failed <br />
+<strong>Actual value:</strong> AXWindow <br />
+; "property AXRoleDescription is web dialog" failed <br />
+<strong>Actual value:</strong> window <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is web dialog" failed <br />
 <strong>Actual value:</strong> dialog <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-75-1' class='subtest'><td>dialog modal unspecified 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-76'><td><a href='http://www.w3c-test.org/wai-aria/div_element_without_role_roledescription_valid-manual.html' target='_blank'>/wai-aria/div_element_without_role_roledescription_valid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-76-0' class='subtest'><td>div element without role roledescription valid</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is group" failed <br />
+<tr id='subtest-75-1' class='subtest'><td>dialog modal unspecified 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-76'><td><a href='http://www.w3c-test.org/wai-aria/div_element_without_role_roledescription_valid-manual.html' target='_blank'>/wai-aria/div_element_without_role_roledescription_valid-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-76-0' class='subtest'><td>div element without role roledescription valid</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is group" failed <br />
 <strong>Actual value:</strong> foo <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property AXRoleDescription is group" failed <br />
 <strong>Actual value:</strong> foo <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-77-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
+<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-77-0' class='subtest'><td>errormessage object in invalid state</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is [error]" failed <br />
 <strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-77-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
+<tr id='subtest-77-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_FOR is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-78-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
+<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-78-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property relations doesNotContain RELATION_ERROR_MESSAGE" failed <br />
+<strong>Actual value:</strong> ['RELATION_LABELLED_BY', 'RELATION_ERROR_MESSAGE'] <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-78-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
+<tr id='subtest-78-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property relations doesNotContain RELATION_ERROR_FOR" failed <br />
+<strong>Actual value:</strong> ['RELATION_ERROR_FOR'] <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-79'><td><a href='http://www.w3c-test.org/wai-aria/feed-manual.html' target='_blank'>/wai-aria/feed-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-79-0' class='subtest'><td>feed</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXGroup" failed <br />
+<tr class='test' id='test-file-79'><td><a href='http://www.w3c-test.org/wai-aria/feed-manual.html' target='_blank'>/wai-aria/feed-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-79-0' class='subtest'><td>feed</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is feed" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXGroup" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: Object not found <br />
 ; "property AXSubrole is AXApplicationGroup" failed <br />
@@ -1340,51 +1616,73 @@ ERROR: Object not found <br />
 ERROR: Object not found <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-80'><td><a href='http://www.w3c-test.org/wai-aria/figure-manual.html' target='_blank'>/wai-aria/figure-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-80-0' class='subtest'><td>figure</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_PANEL" failed <br />
+<tr class='test' id='test-file-80'><td><a href='http://www.w3c-test.org/wai-aria/figure-manual.html' target='_blank'>/wai-aria/figure-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-80-0' class='subtest'><td>figure</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_PANEL" failed <br />
 <strong>Actual value:</strong> ROLE_SECTION <br />
 <a href="https://bugzil.la/1356049">https://bugzil.la/1356049</a>: [NEW] ARIA figure role should be mapped as ATK_ROLE_PANEL <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXApplicationGroup <br />
+; "property AXRoleDescription is figure" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-81'><td><a href='http://www.w3c-test.org/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html' target='_blank'>/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-81-0' class='subtest'><td>grid aria-readonly false automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-81'><td><a href='http://www.w3c-test.org/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html' target='_blank'>/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-81-0' class='subtest'><td>grid aria-readonly false automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-81-1' class='subtest'><td>grid aria-readonly false automatically propagated 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr id='subtest-81-1' class='subtest'><td>grid aria-readonly false automatically propagated 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-81-2' class='subtest'><td>grid aria-readonly false automatically propagated 2</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr id='subtest-81-2' class='subtest'><td>grid aria-readonly false automatically propagated 2</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-82'><td><a href='http://www.w3c-test.org/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html' target='_blank'>/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-82-0' class='subtest'><td>grid aria-readonly true automatically propagated</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-82'><td><a href='http://www.w3c-test.org/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html' target='_blank'>/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-82-0' class='subtest'><td>grid aria-readonly true automatically propagated</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SELECTABLE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-82-1' class='subtest'><td>grid aria-readonly true automatically propagated 1</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr id='subtest-82-1' class='subtest'><td>grid aria-readonly true automatically propagated 1</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-82-2' class='subtest'><td>grid aria-readonly true automatically propagated 2</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr id='subtest-82-2' class='subtest'><td>grid aria-readonly true automatically propagated 2</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-83'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_false-manual.html' target='_blank'>/wai-aria/grid_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-83-0' class='subtest'><td>grid busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
+<tr class='test' id='test-file-83'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_false-manual.html' target='_blank'>/wai-aria/grid_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-83-0' class='subtest'><td>grid busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
 ; "property AXRoleDescription is table" failed <br />
 <strong>Actual value:</strong> grid <br />
@@ -1392,9 +1690,12 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-84'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_true-manual.html' target='_blank'>/wai-aria/grid_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-84-0' class='subtest'><td>grid busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
+<tr class='test' id='test-file-84'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_true-manual.html' target='_blank'>/wai-aria/grid_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-84-0' class='subtest'><td>grid busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
 ; "property AXRoleDescription is table" failed <br />
 <strong>Actual value:</strong> grid <br />
@@ -1402,9 +1703,13 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-85'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_value_changes-manual.html' target='_blank'>/wai-aria/grid_busy_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-85-0' class='subtest'><td>grid busy value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXElementBusyChanged" failed <br />
+<tr class='test' id='test-file-85'><td><a href='http://www.w3c-test.org/wai-aria/grid_busy_value_changes-manual.html' target='_blank'>/wai-aria/grid_busy_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-85-0' class='subtest'><td>grid busy value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is table" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXElementBusy is true" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXElementBusyChanged" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
 ; "property AXSubrole is <nil>" failed <br />
 <strong>Actual value:</strong> grid <br />
@@ -1413,11 +1718,14 @@ ERROR: Object not found <br />
 ; "property AXElementBusy is true" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/wai-aria/grid_colcount_8-manual.html' target='_blank'>/wai-aria/grid_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-86-0' class='subtest'><td>grid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
+<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/wai-aria/grid_colcount_8-manual.html' target='_blank'>/wai-aria/grid_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-86-0' class='subtest'><td>grid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
@@ -1427,36 +1735,57 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-87'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_false-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-87-0' class='subtest'><td>grid columnheader readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-87'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_false-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-87-0' class='subtest'><td>grid columnheader readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-88'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_true-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-88-0' class='subtest'><td>grid columnheader readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-88'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_true-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-88-0' class='subtest'><td>grid columnheader readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-89'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_unspecified-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-89-0' class='subtest'><td>grid columnheader readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-89'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_readonly_unspecified-manual.html' target='_blank'>/wai-aria/grid_columnheader_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-89-0' class='subtest'><td>grid columnheader readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-90'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_false-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-90-0' class='subtest'><td>grid columnheader required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-91'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_true-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-91-0' class='subtest'><td>grid columnheader required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-92'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_unspecified-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-92-0' class='subtest'><td>grid columnheader required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-93'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowcount_3-manual.html' target='_blank'>/wai-aria/grid_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-93-0' class='subtest'><td>grid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
+<tr class='test' id='test-file-90'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_false-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-90-0' class='subtest'><td>grid columnheader required false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRequired is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-91'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_true-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-91-0' class='subtest'><td>grid columnheader required true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRequired is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-92'><td><a href='http://www.w3c-test.org/wai-aria/grid_columnheader_required_unspecified-manual.html' target='_blank'>/wai-aria/grid_columnheader_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-92-0' class='subtest'><td>grid columnheader required unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRequired is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-93'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowcount_3-manual.html' target='_blank'>/wai-aria/grid_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-93-0' class='subtest'><td>grid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowCount is 3" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
@@ -1466,94 +1795,145 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-94'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_false-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-94-0' class='subtest'><td>grid rowheader readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-94'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_false-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-94-0' class='subtest'><td>grid rowheader readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-95'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_true-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-95-0' class='subtest'><td>grid rowheader readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-95'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_true-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-95-0' class='subtest'><td>grid rowheader readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-96'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_unspecified-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-96-0' class='subtest'><td>grid rowheader readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-96'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_readonly_unspecified-manual.html' target='_blank'>/wai-aria/grid_rowheader_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-96-0' class='subtest'><td>grid rowheader readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-97'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_false-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-97-0' class='subtest'><td>grid rowheader required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-98'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_true-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-98-0' class='subtest'><td>grid rowheader required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-99'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_unspecified-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-99-0' class='subtest'><td>grid rowheader required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-100'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/gridcell_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-100-0' class='subtest'><td>gridcell aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
+<tr class='test' id='test-file-97'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_false-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-97-0' class='subtest'><td>grid rowheader required false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRequired is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-98'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_true-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-98-0' class='subtest'><td>grid rowheader required true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRequired is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-99'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowheader_required_unspecified-manual.html' target='_blank'>/wai-aria/grid_rowheader_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-99-0' class='subtest'><td>grid rowheader required unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRequired is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-100'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/gridcell_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-100-0' class='subtest'><td>gridcell aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXColumnIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-101'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-101-0' class='subtest'><td>gridcell aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
+<tr class='test' id='test-file-101'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-101-0' class='subtest'><td>gridcell aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRowIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-102'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_colindex_4-manual.html' target='_blank'>/wai-aria/gridcell_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-102-0' class='subtest'><td>gridcell colindex 4</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr class='test' id='test-file-102'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_colindex_4-manual.html' target='_blank'>/wai-aria/gridcell_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-102-0' class='subtest'><td>gridcell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-103'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_rowindex_4-manual.html' target='_blank'>/wai-aria/gridcell_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-103-0' class='subtest'><td>gridcell rowindex 4</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr class='test' id='test-file-103'><td><a href='http://www.w3c-test.org/wai-aria/gridcell_rowindex_4-manual.html' target='_blank'>/wai-aria/gridcell_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-103-0' class='subtest'><td>gridcell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-104'><td><a href='http://www.w3c-test.org/wai-aria/group_hidden_undefined_element_not_rendered-manual.html' target='_blank'>/wai-aria/group_hidden_undefined_element_not_rendered-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-104-0' class='subtest'><td>group hidden undefined element not rendered</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-105'><td><a href='http://www.w3c-test.org/wai-aria/group_hidden_undefined_element_rendered-manual.html' target='_blank'>/wai-aria/group_hidden_undefined_element_rendered-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-105-0' class='subtest'><td>group hidden undefined element rendered</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<tr class='test' id='test-file-104'><td><a href='http://www.w3c-test.org/wai-aria/group_hidden_undefined_element_not_rendered-manual.html' target='_blank'>/wai-aria/group_hidden_undefined_element_not_rendered-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-104-0' class='subtest'><td>group hidden undefined element not rendered</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-105'><td><a href='http://www.w3c-test.org/wai-aria/group_hidden_undefined_element_rendered-manual.html' target='_blank'>/wai-aria/group_hidden_undefined_element_rendered-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-105-0' class='subtest'><td>group hidden undefined element rendered</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXApplicationGroup" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-106'><td><a href='http://www.w3c-test.org/wai-aria/heading_level_unspecified-manual.html' target='_blank'>/wai-aria/heading_level_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-106-0' class='subtest'><td>heading level unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains level:2" failed <br />
+<tr class='test' id='test-file-106'><td><a href='http://www.w3c-test.org/wai-aria/heading_level_unspecified-manual.html' target='_blank'>/wai-aria/heading_level_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-106-0' class='subtest'><td>heading level unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains level:2" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:heading', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1357100">https://bugzil.la/1357100</a>: [NEW] Implement support for implicit value for aria-level on heading role <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is heading" failed <br />
+<strong>Actual value:</strong> AXHeading <br />
+; "property AXValue is 2" failed <br />
+<strong>Actual value:</strong> 0 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 2" failed <br />
 <strong>Actual value:</strong> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-107'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_multiple_shortcuts-manual.html' target='_blank'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-107-0' class='subtest'><td>keyshortcuts multiple shortcuts</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
+<tr class='test' id='test-file-107'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_multiple_shortcuts-manual.html' target='_blank'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-107-0' class='subtest'><td>keyshortcuts multiple shortcuts</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
+<strong>Actual value:</strong> None <br />
+ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
+ERROR: 'NoneType' object is not callable <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
 ERROR: 'NoneType' object is not callable <br />
@@ -1569,9 +1949,14 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/159215">https://webkit.org/b/159215</a>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-108'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_one_shortcut-manual.html' target='_blank'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-108-0' class='subtest'><td>keyshortcuts one shortcut</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
+<tr class='test' id='test-file-108'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_one_shortcut-manual.html' target='_blank'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-108-0' class='subtest'><td>keyshortcuts one shortcut</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
+<strong>Actual value:</strong> None <br />
+ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
+ERROR: 'NoneType' object is not callable <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
 ERROR: 'NoneType' object is not callable <br />
@@ -1587,123 +1972,206 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/159215">https://webkit.org/b/159215</a>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-109'><td><a href='http://www.w3c-test.org/wai-aria/listbox_busy_false-manual.html' target='_blank'>/wai-aria/listbox_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-109-0' class='subtest'><td>listbox busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
+<tr class='test' id='test-file-109'><td><a href='http://www.w3c-test.org/wai-aria/listbox_busy_false-manual.html' target='_blank'>/wai-aria/listbox_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-109-0' class='subtest'><td>listbox busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-110'><td><a href='http://www.w3c-test.org/wai-aria/listbox_busy_true-manual.html' target='_blank'>/wai-aria/listbox_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-110-0' class='subtest'><td>listbox busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
+<tr class='test' id='test-file-110'><td><a href='http://www.w3c-test.org/wai-aria/listbox_busy_true-manual.html' target='_blank'>/wai-aria/listbox_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-110-0' class='subtest'><td>listbox busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-111'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_horizontal-manual.html' target='_blank'>/wai-aria/listbox_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-111-0' class='subtest'><td>listbox orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-112'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_unspecified-manual.html' target='_blank'>/wai-aria/listbox_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-112-0' class='subtest'><td>listbox orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-113'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_vertical-manual.html' target='_blank'>/wai-aria/listbox_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-113-0' class='subtest'><td>listbox orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-114'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_false-manual.html' target='_blank'>/wai-aria/listbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-114-0' class='subtest'><td>listbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-111'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_horizontal-manual.html' target='_blank'>/wai-aria/listbox_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-111-0' class='subtest'><td>listbox orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-112'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_unspecified-manual.html' target='_blank'>/wai-aria/listbox_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-112-0' class='subtest'><td>listbox orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-113'><td><a href='http://www.w3c-test.org/wai-aria/listbox_orientation_vertical-manual.html' target='_blank'>/wai-aria/listbox_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-113-0' class='subtest'><td>listbox orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-114'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_false-manual.html' target='_blank'>/wai-aria/listbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-114-0' class='subtest'><td>listbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-115'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_true-manual.html' target='_blank'>/wai-aria/listbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-115-0' class='subtest'><td>listbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-115'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_true-manual.html' target='_blank'>/wai-aria/listbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-115-0' class='subtest'><td>listbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-116'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/listbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-116-0' class='subtest'><td>listbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-116'><td><a href='http://www.w3c-test.org/wai-aria/listbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/listbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-116-0' class='subtest'><td>listbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-117'><td><a href='http://www.w3c-test.org/wai-aria/listitem_setsize_-1-manual.html' target='_blank'>/wai-aria/listitem_setsize_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-117-0' class='subtest'><td>listitem setsize -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains setsize:-1" failed <br />
+<tr class='test' id='test-file-117'><td><a href='http://www.w3c-test.org/wai-aria/listitem_setsize_-1-manual.html' target='_blank'>/wai-aria/listitem_setsize_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-117-0' class='subtest'><td>listitem setsize -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains setsize:-1" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'posinset:1', 'margin-top:0px', 'xml-roles:listitem', 'tag:div', 'id:test', 'setsize:1', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1358473">https://bugzil.la/1358473</a>: [NEW] Do not calculate setsize when aria-setsize has a value of -1 <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIASetSize is -1" failed <br />
-<strong>Actual value:</strong> 1 <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-118'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_horizontal-manual.html' target='_blank'>/wai-aria/menu_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-118-0' class='subtest'><td>menu orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-119'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_unspecified-manual.html' target='_blank'>/wai-aria/menu_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-119-0' class='subtest'><td>menu orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-120'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_vertical-manual.html' target='_blank'>/wai-aria/menu_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-120-0' class='subtest'><td>menu orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-121'><td><a href='http://www.w3c-test.org/wai-aria/menubar_busy_false-manual.html' target='_blank'>/wai-aria/menubar_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-121-0' class='subtest'><td>menubar busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIASetSize is -1" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-122'><td><a href='http://www.w3c-test.org/wai-aria/menubar_busy_true-manual.html' target='_blank'>/wai-aria/menubar_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-122-0' class='subtest'><td>menubar busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
+<tr class='test' id='test-file-118'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_horizontal-manual.html' target='_blank'>/wai-aria/menu_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-118-0' class='subtest'><td>menu orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-123'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_horizontal-manual.html' target='_blank'>/wai-aria/menubar_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-123-0' class='subtest'><td>menubar orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-124'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/menubar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-124-0' class='subtest'><td>menubar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-125'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_vertical-manual.html' target='_blank'>/wai-aria/menubar_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-125-0' class='subtest'><td>menubar orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-126'><td><a href='http://www.w3c-test.org/wai-aria/menuitem_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitem_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-126-0' class='subtest'><td>menuitem posinset and setsize</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-127'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-127-0' class='subtest'><td>menuitemcheckbox posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
+<tr class='test' id='test-file-119'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_unspecified-manual.html' target='_blank'>/wai-aria/menu_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-119-0' class='subtest'><td>menu orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-120'><td><a href='http://www.w3c-test.org/wai-aria/menu_orientation_vertical-manual.html' target='_blank'>/wai-aria/menu_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-120-0' class='subtest'><td>menu orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-121'><td><a href='http://www.w3c-test.org/wai-aria/menubar_busy_false-manual.html' target='_blank'>/wai-aria/menubar_busy_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-121-0' class='subtest'><td>menubar busy false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-122'><td><a href='http://www.w3c-test.org/wai-aria/menubar_busy_true-manual.html' target='_blank'>/wai-aria/menubar_busy_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-122-0' class='subtest'><td>menubar busy true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXElementBusy is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-123'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_horizontal-manual.html' target='_blank'>/wai-aria/menubar_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-123-0' class='subtest'><td>menubar orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-124'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/menubar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-124-0' class='subtest'><td>menubar orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-125'><td><a href='http://www.w3c-test.org/wai-aria/menubar_orientation_vertical-manual.html' target='_blank'>/wai-aria/menubar_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-125-0' class='subtest'><td>menubar orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-126'><td><a href='http://www.w3c-test.org/wai-aria/menuitem_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitem_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-126-0' class='subtest'><td>menuitem posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXARIASetSize is 8" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-127'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-127-0' class='subtest'><td>menuitemcheckbox posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXValue is 1" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXARIAPosInSet is 4" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXARIASetSize is 8" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ; "property AXARIASetSize is 8" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-128'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_false-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-128-0' class='subtest'><td>menuitemcheckbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-128'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_false-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-128-0' class='subtest'><td>menuitemcheckbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-129'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_true-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-129-0' class='subtest'><td>menuitemcheckbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-129'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_true-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-129-0' class='subtest'><td>menuitemcheckbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-130'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-130-0' class='subtest'><td>menuitemcheckbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-130'><td><a href='http://www.w3c-test.org/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-130-0' class='subtest'><td>menuitemcheckbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-131'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitemradio_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-131-0' class='subtest'><td>menuitemradio posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
+<tr class='test' id='test-file-131'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/menuitemradio_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-131-0' class='subtest'><td>menuitemradio posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXValue is 0" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXARIAPosInSet is 4" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXARIASetSize is 8" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 4" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ; "property AXARIASetSize is 8" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-132'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_false-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-132-0' class='subtest'><td>menuitemradio readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-132'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_false-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-132-0' class='subtest'><td>menuitemradio readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-133'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_true-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-133-0' class='subtest'><td>menuitemradio readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKABLE" failed <br />
+<tr class='test' id='test-file-133'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_true-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-133-0' class='subtest'><td>menuitemradio readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ; "property states contains STATE_READ_ONLY" failed <br />
@@ -1711,24 +2179,33 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-134'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_unspecified-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-134-0' class='subtest'><td>menuitemradio readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-134'><td><a href='http://www.w3c-test.org/wai-aria/menuitemradio_readonly_unspecified-manual.html' target='_blank'>/wai-aria/menuitemradio_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-134-0' class='subtest'><td>menuitemradio readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/wai-aria/none-manual.html' target='_blank'>/wai-aria/none-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-135-0' class='subtest'><td>none</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-136'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_false-manual.html' target='_blank'>/wai-aria/option_selected_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-136-0' class='subtest'><td>option selected false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_SELECTABLE" failed <br />
+<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/wai-aria/none-manual.html' target='_blank'>/wai-aria/none-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-135-0' class='subtest'><td>none</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-136'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_false-manual.html' target='_blank'>/wai-aria/option_selected_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-136-0' class='subtest'><td>option selected false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSelected is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_SELECTABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE'] <br />
 <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a>: [NEW] [ATK] Options in an ARIA listbox should have STATE_SELECTABLE and emit selection-related events <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-137'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_true-manual.html' target='_blank'>/wai-aria/option_selected_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-137-0' class='subtest'><td>option selected true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
+<tr class='test' id='test-file-137'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_true-manual.html' target='_blank'>/wai-aria/option_selected_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-137-0' class='subtest'><td>option selected true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSelected is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_SELECTABLE" failed <br />
@@ -1736,76 +2213,107 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a>: [NEW] [ATK] Options in an ARIA listbox should have STATE_SELECTABLE and emit selection-related events <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-138'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_undefined-manual.html' target='_blank'>/wai-aria/option_selected_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-138-0' class='subtest'><td>option selected undefined</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_SELECTABLE" failed <br />
+<tr class='test' id='test-file-138'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_undefined-manual.html' target='_blank'>/wai-aria/option_selected_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-138-0' class='subtest'><td>option selected undefined</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSelected is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_SELECTABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE'] <br />
 <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a>: [NEW] [ATK] Options in an ARIA listbox should have STATE_SELECTABLE and emit selection-related events <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-139'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_value_changes-manual.html' target='_blank'>/wai-aria/option_selected_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-139-0' class='subtest'><td>option selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
+<tr class='test' id='test-file-139'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_value_changes-manual.html' target='_blank'>/wai-aria/option_selected_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-139-0' class='subtest'><td>option selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-139-1' class='subtest'><td>option selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
+<tr id='subtest-139-1' class='subtest'><td>option selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:selection-changed" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-139-2' class='subtest'><td>option selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
+<tr id='subtest-139-2' class='subtest'><td>option selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-140'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_horizontal-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-140-0' class='subtest'><td>radiogroup orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-141'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_unspecified-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-141-0' class='subtest'><td>radiogroup orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXOrientation is AXUnknownOrientation" failed <br />
+<tr class='test' id='test-file-140'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_horizontal-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-140-0' class='subtest'><td>radiogroup orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-141'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_unspecified-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-141-0' class='subtest'><td>radiogroup orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXUnknownOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXOrientation is AXUnknownOrientation" failed <br />
 <strong>Actual value:</strong> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-142'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_vertical-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-142-0' class='subtest'><td>radiogroup orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-143'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_false-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-143-0' class='subtest'><td>radiogroup readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-142'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_orientation_vertical-manual.html' target='_blank'>/wai-aria/radiogroup_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-142-0' class='subtest'><td>radiogroup orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-143'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_false-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-143-0' class='subtest'><td>radiogroup readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-144'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_true-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-144-0' class='subtest'><td>radiogroup readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-144'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_true-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-144-0' class='subtest'><td>radiogroup readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-145'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_unspecified-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-145-0' class='subtest'><td>radiogroup readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-145'><td><a href='http://www.w3c-test.org/wai-aria/radiogroup_readonly_unspecified-manual.html' target='_blank'>/wai-aria/radiogroup_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-145-0' class='subtest'><td>radiogroup readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-146'><td><a href='http://www.w3c-test.org/wai-aria/region_with_name-manual.html' target='_blank'>/wai-aria/region_with_name-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-146-0' class='subtest'><td>region with name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_LANDMARK" failed <br />
+<tr class='test' id='test-file-146'><td><a href='http://www.w3c-test.org/wai-aria/region_with_name-manual.html' target='_blank'>/wai-aria/region_with_name-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-146-0' class='subtest'><td>region with name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_LANDMARK" failed <br />
 <strong>Actual value:</strong> ROLE_PANEL <br />
 <a href="https://bugzil.la/1210630">https://bugzil.la/1210630</a>: [NEW] Section elements with accessible names should be mapped the same as ARIA role region <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
+<strong>Actual value:</strong> AXDocumentRegion <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXLandmarkRegion" failed <br />
 <strong>Actual value:</strong> AXDocumentRegion <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-147'><td><a href='http://www.w3c-test.org/wai-aria/region_without_name-manual.html' target='_blank'>/wai-aria/region_without_name-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-147-0' class='subtest'><td>region without name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_SECTION" failed <br />
+<tr class='test' id='test-file-147'><td><a href='http://www.w3c-test.org/wai-aria/region_without_name-manual.html' target='_blank'>/wai-aria/region_without_name-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-147-0' class='subtest'><td>region without name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE_SECTION" failed <br />
 <strong>Actual value:</strong> ROLE_PANEL <br />
 <a href="https://bugzil.la/1358462">https://bugzil.la/1358462</a>: [NEW] Elements with role="region" and no accessible name should be mapped according to host language <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXDocumentRegion <br />
+; "property AXRoleDescription is group" failed <br />
+<strong>Actual value:</strong> region <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
 <strong>Actual value:</strong> AXDocumentRegion <br />
@@ -1813,17 +2321,20 @@ ERROR: 'NoneType' object is not callable <br />
 <strong>Actual value:</strong> region <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-148'><td><a href='http://www.w3c-test.org/wai-aria/row_colindex_4-manual.html' target='_blank'>/wai-aria/row_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-148-0' class='subtest'><td>row colindex 4</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains colindex:4" failed <br />
+<tr class='test' id='test-file-148'><td><a href='http://www.w3c-test.org/wai-aria/row_colindex_4-manual.html' target='_blank'>/wai-aria/row_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-148-0' class='subtest'><td>row colindex 4</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains colindex:4" failed <br />
 <strong>Actual value:</strong> ['computed-role:row', 'xml-roles:row', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk'] <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-148-1' class='subtest'><td>row colindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr id='subtest-148-1' class='subtest'><td>row colindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -1833,17 +2344,20 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-149'><td><a href='http://www.w3c-test.org/wai-aria/row_rowindex_4-manual.html' target='_blank'>/wai-aria/row_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-149-0' class='subtest'><td>row rowindex 4</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains rowindex:4" failed <br />
+<tr class='test' id='test-file-149'><td><a href='http://www.w3c-test.org/wai-aria/row_rowindex_4-manual.html' target='_blank'>/wai-aria/row_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-149-0' class='subtest'><td>row rowindex 4</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains rowindex:4" failed <br />
 <strong>Actual value:</strong> ['computed-role:row', 'xml-roles:row', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk'] <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-149-1' class='subtest'><td>row rowindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr id='subtest-149-1' class='subtest'><td>row rowindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -1853,31 +2367,40 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-150'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/rowheader_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-150-0' class='subtest'><td>rowheader aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
+<tr class='test' id='test-file-150'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_aria-colspan_2_on_div-manual.html' target='_blank'>/wai-aria/rowheader_aria-colspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-150-0' class='subtest'><td>rowheader aria-colspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains column_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXColumnIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-151'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-151-0' class='subtest'><td>rowheader aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
+<tr class='test' id='test-file-151'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html' target='_blank'>/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-151-0' class='subtest'><td>rowheader aria-rowspan 2 on div</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>row<em>column</em>span() contains row_span=2" failed <br />
 <strong>Actual value:</strong> (row=0, column=0, row_span=1, column_span=1) <br />
 <a href="https://bugzil.la/1357013">https://bugzil.la/1357013</a>: [NEW] atk_table_cell_get_row_column_span() should report the values of aria-rowspan and aria-colspan <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
+<strong>Actual value:</strong> 1 <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRowIndexRange.length is 2" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-152'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_colindex_4-manual.html' target='_blank'>/wai-aria/rowheader_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-152-0' class='subtest'><td>rowheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr class='test' id='test-file-152'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_colindex_4-manual.html' target='_blank'>/wai-aria/rowheader_colindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-152-0' class='subtest'><td>rowheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -1887,11 +2410,14 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-153'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_rowindex_4-manual.html' target='_blank'>/wai-aria/rowheader_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-153-0' class='subtest'><td>rowheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr class='test' id='test-file-153'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_rowindex_4-manual.html' target='_blank'>/wai-aria/rowheader_rowindex_4-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-153-0' class='subtest'><td>rowheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -1901,17 +2427,32 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-154'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-154-0' class='subtest'><td>rowheader selected false not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
+<tr class='test' id='test-file-154'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-154-0' class='subtest'><td>rowheader selected false not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is cell" failed <br />
+<strong>Actual value:</strong> group <br />
+; "property AXSelected is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSelected is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-155'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-155-0' class='subtest'><td>rowheader selected true not automatically propagated</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-156'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_all_values_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-156-0' class='subtest'><td>scrollbar all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() is 0" failed <br />
+<tr class='test' id='test-file-155'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html' target='_blank'>/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-155-0' class='subtest'><td>rowheader selected true not automatically propagated</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXCell" failed <br />
+<strong>Actual value:</strong> AXGroup <br />
+; "property AXRoleDescription is cell" failed <br />
+<strong>Actual value:</strong> group <br />
+; "property AXSelected is false" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-156'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_all_values_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-156-0' class='subtest'><td>scrollbar all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() is 0" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: atspi_error: Get failed (1) <br />
 <a href="https://bugzil.la/1357071">https://bugzil.la/1357071</a>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles <br />
@@ -1922,49 +2463,79 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 <a href="https://bugzil.la/1357071">https://bugzil.la/1357071</a>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXMinValue is 0" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 50" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXMaxValue is 100" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 50" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ; "property AXMaxValue is 100" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-157'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-157-0' class='subtest'><td>scrollbar only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>current</em>value() is 20" failed <br />
+<tr class='test' id='test-file-157'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-157-0' class='subtest'><td>scrollbar only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>current</em>value() is 20" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 <a href="https://bugzil.la/1357071">https://bugzil.la/1357071</a>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXMinValue is 0" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 20" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXMaxValue is 40" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 20" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-158'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-158-0' class='subtest'><td>scrollbar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-159'><td><a href='http://www.w3c-test.org/wai-aria/searchbox-manual.html' target='_blank'>/wai-aria/searchbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-159-0' class='subtest'><td>searchbox</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
+<tr class='test' id='test-file-158'><td><a href='http://www.w3c-test.org/wai-aria/scrollbar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/scrollbar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-158-0' class='subtest'><td>scrollbar orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-159'><td><a href='http://www.w3c-test.org/wai-aria/searchbox-manual.html' target='_blank'>/wai-aria/searchbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-159-0' class='subtest'><td>searchbox</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
 <strong>Actual value:</strong> AXTextArea <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-160-0' class='subtest'><td>searchbox activedescendant</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states doesNotContain STATE_FOCUSED" failed <br />
+<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-160-0' class='subtest'><td>searchbox activedescendant</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states doesNotContain STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_EDITABLE', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_FOCUSED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_SINGLE_LINE', 'STATE_VISIBLE'] <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property AXFocused is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -1981,9 +2552,17 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-161-0' class='subtest'><td>searchbox activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result array isNot true" failed <br />
+<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-161-0' class='subtest'><td>searchbox activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+; "event type is AXSelectedChildrenChanged" failed <br />
+<strong>Actual value:</strong> false <br />
+; "result array isNot true" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result array isNot true" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states doesNotContain STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_EDITABLE', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_FOCUSED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_SINGLE_LINE', 'STATE_VISIBLE'] <br />
@@ -1993,16 +2572,18 @@ ERROR: Object not found <br />
 ; "result array isNot true" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -2019,67 +2600,154 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-162'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_both-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_both-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-162-0' class='subtest'><td>searchbox autocomplete both</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-163'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_inline-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_inline-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-163-0' class='subtest'><td>searchbox autocomplete inline</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-164'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_list-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_list-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-164-0' class='subtest'><td>searchbox autocomplete list</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-165'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_none-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_none-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-165-0' class='subtest'><td>searchbox autocomplete none</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-166'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-166-0' class='subtest'><td>searchbox autocomplete unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-167'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_false-manual.html' target='_blank'>/wai-aria/searchbox_multiline_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-167-0' class='subtest'><td>searchbox multiline false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
-<strong>Actual value:</strong> AXTextArea <br />
+<tr class='test' id='test-file-162'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_both-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_both-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-162-0' class='subtest'><td>searchbox autocomplete both</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-168'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_true-manual.html' target='_blank'>/wai-aria/searchbox_multiline_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-168-0' class='subtest'><td>searchbox multiline true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
-<strong>Actual value:</strong> AXTextArea <br />
+<tr class='test' id='test-file-163'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_inline-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_inline-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-163-0' class='subtest'><td>searchbox autocomplete inline</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-169'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_multiline_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-169-0' class='subtest'><td>searchbox multiline unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
-<strong>Actual value:</strong> AXTextArea <br />
+<tr class='test' id='test-file-164'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_list-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_list-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-164-0' class='subtest'><td>searchbox autocomplete list</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-170'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_placeholder-manual.html' target='_blank'>/wai-aria/searchbox_placeholder-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-170-0' class='subtest'><td>searchbox placeholder</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains placeholder-text:DD/MM/YYYY" failed <br />
-<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'placeholder:DD/MM/YYYY', 'margin-top:0px', 'xml-roles:searchbox', 'text-input-type:search', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
-<a href="https://bugzil.la/1303429">https://bugzil.la/1303429</a>: [NEW] expose placeholder object attribute for HTML placeholder <br />
+<tr class='test' id='test-file-165'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_none-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_none-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-165-0' class='subtest'><td>searchbox autocomplete none</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-166'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_autocomplete_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_autocomplete_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-166-0' class='subtest'><td>searchbox autocomplete unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-167'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_false-manual.html' target='_blank'>/wai-aria/searchbox_multiline_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-167-0' class='subtest'><td>searchbox multiline false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
 <strong>Actual value:</strong> AXTextArea <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-171'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_false-manual.html' target='_blank'>/wai-aria/searchbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-171-0' class='subtest'><td>searchbox readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-172'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_true-manual.html' target='_blank'>/wai-aria/searchbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-172-0' class='subtest'><td>searchbox readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces doesNotContain EditableText" failed <br />
+<tr class='test' id='test-file-168'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_true-manual.html' target='_blank'>/wai-aria/searchbox_multiline_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-168-0' class='subtest'><td>searchbox multiline true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
+<strong>Actual value:</strong> AXTextArea <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-169'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_multiline_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_multiline_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-169-0' class='subtest'><td>searchbox multiline unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
+<strong>Actual value:</strong> AXTextArea <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-170'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_placeholder-manual.html' target='_blank'>/wai-aria/searchbox_placeholder-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-170-0' class='subtest'><td>searchbox placeholder</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains placeholder-text:DD/MM/YYYY" failed <br />
+<strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'placeholder:DD/MM/YYYY', 'margin-top:0px', 'xml-roles:searchbox', 'text-input-type:search', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
+<a href="https://bugzil.la/1303429">https://bugzil.la/1303429</a>: [NEW] expose placeholder object attribute for HTML placeholder <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+; "property AXPlaceholderValue is DD/MM/YYYY" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
+<strong>Actual value:</strong> AXTextArea <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-171'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_false-manual.html' target='_blank'>/wai-aria/searchbox_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-171-0' class='subtest'><td>searchbox readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+; "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-172'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_true-manual.html' target='_blank'>/wai-aria/searchbox_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-172-0' class='subtest'><td>searchbox readonly true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces doesNotContain EditableText" failed <br />
 <strong>Actual value:</strong> ['Accessible', 'Action', 'Collection', 'Component', 'EditableText', 'Hypertext', 'Hyperlink', 'Text'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ; "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_SINGLE_LINE', 'STATE_VISIBLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+; "result AXUIElementIsAttributeSettable(AXValue) is false" failed <br />
+<strong>Actual value:</strong> true <br />
+;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-173'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-173-0' class='subtest'><td>searchbox readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-174'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_false-manual.html' target='_blank'>/wai-aria/searchbox_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-174-0' class='subtest'><td>searchbox required false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-175'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_true-manual.html' target='_blank'>/wai-aria/searchbox_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-175-0' class='subtest'><td>searchbox required true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-176'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-176-0' class='subtest'><td>searchbox required unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-177'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_all_values_unspecified-manual.html' target='_blank'>/wai-aria/separator_focusable_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-177-0' class='subtest'><td>separator focusable all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces contains Value" failed <br />
+<tr class='test' id='test-file-173'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_readonly_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-173-0' class='subtest'><td>searchbox readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+; "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-174'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_false-manual.html' target='_blank'>/wai-aria/searchbox_required_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-174-0' class='subtest'><td>searchbox required false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-175'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_true-manual.html' target='_blank'>/wai-aria/searchbox_required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-175-0' class='subtest'><td>searchbox required true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-176'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_required_unspecified-manual.html' target='_blank'>/wai-aria/searchbox_required_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-176-0' class='subtest'><td>searchbox required unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-177'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_all_values_unspecified-manual.html' target='_blank'>/wai-aria/separator_focusable_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-177-0' class='subtest'><td>separator focusable all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces contains Value" failed <br />
 <strong>Actual value:</strong> ['Accessible', 'Collection', 'Component', 'Hyperlink'] <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
 ; "result atk<em>value</em>get<em>minimum</em>value() is 0" failed <br />
@@ -2095,15 +2763,26 @@ ERROR: atspi_error: Get failed (1) <br />
 ERROR: atspi_error: Get failed (1) <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 50" failed <br />
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXContentSeparator <br />
+; "property AXRoleDescription is splitter" failed <br />
+<strong>Actual value:</strong> separator <br />
+; "property AXMinValue is 0" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 50" failed <br />
 <strong>Actual value:</strong> <br />
+; "property AXMaxValue is 100" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 50" failed <br />
+<strong>Actual value:</strong> 0.0 <br />
 ; "property AXMaxValue is 100" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-178'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-178-0' class='subtest'><td>separator focusable only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces contains Value" failed <br />
+<tr class='test' id='test-file-178'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-178-0' class='subtest'><td>separator focusable only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property interfaces contains Value" failed <br />
 <strong>Actual value:</strong> ['Accessible', 'Collection', 'Component', 'Hyperlink'] <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
 ; "result atk<em>value</em>get<em>minimum</em>value() is 0" failed <br />
@@ -2119,15 +2798,24 @@ ERROR: atspi_error: Get failed (1) <br />
 ERROR: atspi_error: Get failed (1) <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 50" failed <br />
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXContentSeparator <br />
+; "property AXRoleDescription is splitter" failed <br />
+<strong>Actual value:</strong> separator <br />
+; "property AXMinValue is 0" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 50" failed <br />
 <strong>Actual value:</strong> <br />
 ; "property AXMaxValue is 100" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 50" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-179'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_valuetext-manual.html' target='_blank'>/wai-aria/separator_focusable_valuetext-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-179-0' class='subtest'><td>separator focusable valuetext</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains valuetext:Bonaire" failed <br />
+<tr class='test' id='test-file-179'><td><a href='http://www.w3c-test.org/wai-aria/separator_focusable_valuetext-manual.html' target='_blank'>/wai-aria/separator_focusable_valuetext-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-179-0' class='subtest'><td>separator focusable valuetext</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains valuetext:Bonaire" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:separator', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
 ; "property interfaces contains Value" failed <br />
@@ -2146,23 +2834,54 @@ ERROR: atspi_error: Get failed (1) <br />
 ERROR: atspi_error: Get failed (1) <br />
 <a href="https://bugzil.la/1355954">https://bugzil.la/1355954</a>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 50" failed <br />
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXContentSeparator <br />
+; "property AXRoleDescription is splitter" failed <br />
+<strong>Actual value:</strong> separator <br />
+; "property AXMinValue is 0" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 50" failed <br />
 <strong>Actual value:</strong> <br />
 ; "property AXMaxValue is 100" failed <br />
-<strong>Actual value:</strong> 0.0 <br />
+<strong>Actual value:</strong> None <br />
 ; "property AXValueDescription is Bonaire" failed <br />
-<strong>Actual value:</strong> <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 50" failed <br />
+<strong>Actual value:</strong> 0.0 <br />
+; "property AXMaxValue is 100" failed <br />
+<strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-180'><td><a href='http://www.w3c-test.org/wai-aria/separator_orientation_unspecified-manual.html' target='_blank'>/wai-aria/separator_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-180-0' class='subtest'><td>separator orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-181'><td><a href='http://www.w3c-test.org/wai-aria/separator_unfocusable_all_values_unspecified-manual.html' target='_blank'>/wai-aria/separator_unfocusable_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-181-0' class='subtest'><td>separator unfocusable all values unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-182'><td><a href='http://www.w3c-test.org/wai-aria/separator_unfocusable_valuetext-manual.html' target='_blank'>/wai-aria/separator_unfocusable_valuetext-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-182-0' class='subtest'><td>separator unfocusable valuetext</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-183'><td><a href='http://www.w3c-test.org/wai-aria/slider_all_values_unspecified-manual.html' target='_blank'>/wai-aria/slider_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-183-0' class='subtest'><td>slider all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() is 0" failed <br />
+<tr class='test' id='test-file-180'><td><a href='http://www.w3c-test.org/wai-aria/separator_orientation_unspecified-manual.html' target='_blank'>/wai-aria/separator_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-180-0' class='subtest'><td>separator orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXContentSeparator <br />
+; "property AXRoleDescription is splitter" failed <br />
+<strong>Actual value:</strong> separator <br />
+; "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-181'><td><a href='http://www.w3c-test.org/wai-aria/separator_unfocusable_all_values_unspecified-manual.html' target='_blank'>/wai-aria/separator_unfocusable_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-181-0' class='subtest'><td>separator unfocusable all values unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXContentSeparator <br />
+; "property AXRoleDescription is splitter" failed <br />
+<strong>Actual value:</strong> separator <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-182'><td><a href='http://www.w3c-test.org/wai-aria/separator_unfocusable_valuetext-manual.html' target='_blank'>/wai-aria/separator_unfocusable_valuetext-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-182-0' class='subtest'><td>separator unfocusable valuetext</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is <nil>" failed <br />
+<strong>Actual value:</strong> AXContentSeparator <br />
+; "property AXRoleDescription is splitter" failed <br />
+<strong>Actual value:</strong> separator <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-183'><td><a href='http://www.w3c-test.org/wai-aria/slider_all_values_unspecified-manual.html' target='_blank'>/wai-aria/slider_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-183-0' class='subtest'><td>slider all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() is 0" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: atspi_error: Get failed (1) <br />
 <a href="https://bugzil.la/1357071">https://bugzil.la/1357071</a>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles <br />
@@ -2173,38 +2892,64 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 <a href="https://bugzil.la/1357071">https://bugzil.la/1357071</a>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXMinValue is 0" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 50" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXMaxValue is 100" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 50" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ; "property AXMaxValue is 100" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-184'><td><a href='http://www.w3c-test.org/wai-aria/slider_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/slider_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-184-0' class='subtest'><td>slider only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>current</em>value() is 20" failed <br />
+<tr class='test' id='test-file-184'><td><a href='http://www.w3c-test.org/wai-aria/slider_only_valuenow_unspecified-manual.html' target='_blank'>/wai-aria/slider_only_valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-184-0' class='subtest'><td>slider only valuenow unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>current</em>value() is 20" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 <a href="https://bugzil.la/1357071">https://bugzil.la/1357071</a>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXMinValue is 0" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 20" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXMaxValue is 40" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 20" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-185'><td><a href='http://www.w3c-test.org/wai-aria/slider_orientation_unspecified-manual.html' target='_blank'>/wai-aria/slider_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-185-0' class='subtest'><td>slider orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-186'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_false-manual.html' target='_blank'>/wai-aria/slider_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-186-0' class='subtest'><td>slider readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-187'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_true-manual.html' target='_blank'>/wai-aria/slider_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-187-0' class='subtest'><td>slider readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-185'><td><a href='http://www.w3c-test.org/wai-aria/slider_orientation_unspecified-manual.html' target='_blank'>/wai-aria/slider_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-185-0' class='subtest'><td>slider orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-186'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_false-manual.html' target='_blank'>/wai-aria/slider_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-186-0' class='subtest'><td>slider readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-187'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_true-manual.html' target='_blank'>/wai-aria/slider_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-187-0' class='subtest'><td>slider readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-188'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_unspecified-manual.html' target='_blank'>/wai-aria/slider_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-188-0' class='subtest'><td>slider readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-189'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_all_values_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-189-0' class='subtest'><td>spinbutton all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() isLTE -9007199254740992" failed <br />
+<tr class='test' id='test-file-188'><td><a href='http://www.w3c-test.org/wai-aria/slider_readonly_unspecified-manual.html' target='_blank'>/wai-aria/slider_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-188-0' class='subtest'><td>slider readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-189'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_all_values_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_all_values_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-189-0' class='subtest'><td>spinbutton all values unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>value</em>get<em>minimum</em>value() isLTE -9007199254740992" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: atspi_error: Get failed (1) <br />
 <a href="https://bugzil.la/1357097">https://bugzil.la/1357097</a>: [NEW] Implement support for implicit values for aria-value* attributes for spinbutton role <br />
@@ -2212,62 +2957,120 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> 0.0 <br />
 <a href="https://bugzil.la/1357097">https://bugzil.la/1357097</a>: [NEW] Implement support for implicit values for aria-value* attributes for spinbutton role <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXMinValue isLTE -9007199254740992" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 0" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXMaxValue isGTE 9007199254740992" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXMinValue isLTE -9007199254740992" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ; "property AXMaxValue isGTE 9007199254740992" failed <br />
 <strong>Actual value:</strong> 0.0 <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-190'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-190-0' class='subtest'><td>spinbutton only aria-valuenow unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-191'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_false-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-191-0' class='subtest'><td>spinbutton readonly false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-192'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_true-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-192-0' class='subtest'><td>spinbutton readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-190'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-190-0' class='subtest'><td>spinbutton only aria-valuenow unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXMinValue is 0" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXValue is 0" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXMaxValue is 100" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-191'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_false-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-191-0' class='subtest'><td>spinbutton readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-192'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_true-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-192-0' class='subtest'><td>spinbutton readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-193'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-193-0' class='subtest'><td>spinbutton readonly unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-194'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_false-manual.html' target='_blank'>/wai-aria/switch_checked_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-194-0' class='subtest'><td>switch checked false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-195'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_mixed-manual.html' target='_blank'>/wai-aria/switch_checked_mixed-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-195-0' class='subtest'><td>switch checked mixed</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKED" failed <br />
-<strong>Actual value:</strong> ['STATE_CHECKED', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
-<a href="https://bugzil.la/1358447">https://bugzil.la/1358447</a>: [NEW] Elements with aria-checked="mixed" and role="switch" should not expose ATK_STATE_CHECKED <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-196'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_true-manual.html' target='_blank'>/wai-aria/switch_checked_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-196-0' class='subtest'><td>switch checked true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-197'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_undefined-manual.html' target='_blank'>/wai-aria/switch_checked_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-197-0' class='subtest'><td>switch checked undefined</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-198'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_value_changes-manual.html' target='_blank'>/wai-aria/switch_checked_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-198-0' class='subtest'><td>switch checked value changes</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-199'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_false-manual.html' target='_blank'>/wai-aria/switch_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-199-0' class='subtest'><td>switch readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-193'><td><a href='http://www.w3c-test.org/wai-aria/spinbutton_readonly_unspecified-manual.html' target='_blank'>/wai-aria/spinbutton_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-193-0' class='subtest'><td>spinbutton readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-200'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_true-manual.html' target='_blank'>/wai-aria/switch_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-200-0' class='subtest'><td>switch readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
+<tr class='test' id='test-file-194'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_false-manual.html' target='_blank'>/wai-aria/switch_checked_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-194-0' class='subtest'><td>switch checked false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXValue is 0" failed <br />
+<strong>Actual value:</strong> <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-195'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_mixed-manual.html' target='_blank'>/wai-aria/switch_checked_mixed-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-195-0' class='subtest'><td>switch checked mixed</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_CHECKED" failed <br />
+<strong>Actual value:</strong> ['STATE_CHECKED', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
+<a href="https://bugzil.la/1358447">https://bugzil.la/1358447</a>: [NEW] Elements which do not support aria-checked="mixed" should not expose "checked" accessibility state <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXValue is 0" failed <br />
+<strong>Actual value:</strong> <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-196'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_true-manual.html' target='_blank'>/wai-aria/switch_checked_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-196-0' class='subtest'><td>switch checked true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXValue is 1" failed <br />
+<strong>Actual value:</strong> <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-197'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_undefined-manual.html' target='_blank'>/wai-aria/switch_checked_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-197-0' class='subtest'><td>switch checked undefined</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXValue is 0" failed <br />
+<strong>Actual value:</strong> <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-198'><td><a href='http://www.w3c-test.org/wai-aria/switch_checked_value_changes-manual.html' target='_blank'>/wai-aria/switch_checked_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-198-0' class='subtest'><td>switch checked value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRoleDescription is switch" failed <br />
+<strong>Actual value:</strong> <br />
+; "property AXValue is 1" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXValue is 1" failed <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-199'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_false-manual.html' target='_blank'>/wai-aria/switch_readonly_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-199-0' class='subtest'><td>switch readonly false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-200'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_true-manual.html' target='_blank'>/wai-aria/switch_readonly_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-200-0' class='subtest'><td>switch readonly true</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_READ_ONLY" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-201'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_unspecified-manual.html' target='_blank'>/wai-aria/switch_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-201-0' class='subtest'><td>switch readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<tr class='test' id='test-file-201'><td><a href='http://www.w3c-test.org/wai-aria/switch_readonly_unspecified-manual.html' target='_blank'>/wai-aria/switch_readonly_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-201-0' class='subtest'><td>switch readonly unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXValue) is true" failed <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-202'><td><a href='http://www.w3c-test.org/wai-aria/tab_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/tab_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-202-0' class='subtest'><td>tab posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 3" failed <br />
+<tr class='test' id='test-file-202'><td><a href='http://www.w3c-test.org/wai-aria/tab_posinset_and_setsize-manual.html' target='_blank'>/wai-aria/tab_posinset_and_setsize-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-202-0' class='subtest'><td>tab posinset and setsize</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAPosInSet is 3" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXARIASetSize is 7" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXSelected is true" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAPosInSet is 3" failed <br />
 <strong>Actual value:</strong> 0 <br />
 ; "property AXARIASetSize is 7" failed <br />
 <strong>Actual value:</strong> 0 <br />
@@ -2275,11 +3078,14 @@ ERROR: atspi_error: Get failed (1) <br />
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-203'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_-1-manual.html' target='_blank'>/wai-aria/table_colcount_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-203-0' class='subtest'><td>table colcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is -1" failed <br />
+<tr class='test' id='test-file-203'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_-1-manual.html' target='_blank'>/wai-aria/table_colcount_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-203-0' class='subtest'><td>table colcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is -1" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is -1" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnCount is -1" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -2289,11 +3095,14 @@ ERROR: atspi_error: Get failed (1) <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-204'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_8-manual.html' target='_blank'>/wai-aria/table_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-204-0' class='subtest'><td>table colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
+<tr class='test' id='test-file-204'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_8-manual.html' target='_blank'>/wai-aria/table_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-204-0' class='subtest'><td>table colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -2303,13 +3112,16 @@ ERROR: atspi_error: Get failed (1) <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-205'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_-1-manual.html' target='_blank'>/wai-aria/table_rowcount_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-205-0' class='subtest'><td>table rowcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is -1" failed <br />
+<tr class='test' id='test-file-205'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_-1-manual.html' target='_blank'>/wai-aria/table_rowcount_-1-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-205-0' class='subtest'><td>table rowcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is -1" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowCount is -1" failed <br />
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowCount contains -1" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowCount contains -1" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is -1" failed <br />
@@ -2317,11 +3129,14 @@ ERROR: atspi_error: Get failed (1) <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-206'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_3-manual.html' target='_blank'>/wai-aria/table_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-206-0' class='subtest'><td>table rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
+<tr class='test' id='test-file-206'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_3-manual.html' target='_blank'>/wai-aria/table_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-206-0' class='subtest'><td>table rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowCount is 3" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowCount is 3" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -2331,28 +3146,34 @@ ERROR: atspi_error: Get failed (1) <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-207'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_horizontal-manual.html' target='_blank'>/wai-aria/tablist_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-207-0' class='subtest'><td>tablist orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-208'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_unspecified-manual.html' target='_blank'>/wai-aria/tablist_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-208-0' class='subtest'><td>tablist orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-209'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_vertical-manual.html' target='_blank'>/wai-aria/tablist_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-209-0' class='subtest'><td>tablist orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-210'><td><a href='http://www.w3c-test.org/wai-aria/term_role-manual.html' target='_blank'>/wai-aria/term_role-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-210-0' class='subtest'><td>term role</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE<em>DESCRIPTION</em>TERM" failed <br />
-<strong>Actual value:</strong> ROLE_SECTION <br />
-<a href="https://bugzil.la/1358417">https://bugzil.la/1358417</a>: [NEW] ARIA term role should be exposed with ATK_ROLE_DESCRIPTION_TERM <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property role is ROLE<em>DESCRIPTION</em>TERM" failed <br />
-<strong>Actual value:</strong> ROLE_UNKNOWN <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 is missing roles that are present in ATK <br />
+<tr class='test' id='test-file-207'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_horizontal-manual.html' target='_blank'>/wai-aria/tablist_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-207-0' class='subtest'><td>tablist orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-211'><td><a href='http://www.w3c-test.org/wai-aria/textbox_placeholder-manual.html' target='_blank'>/wai-aria/textbox_placeholder-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-211-0' class='subtest'><td>textbox placeholder</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains placeholder-text:DD/MM/YYYY" failed <br />
+<tr class='test' id='test-file-208'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_unspecified-manual.html' target='_blank'>/wai-aria/tablist_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-208-0' class='subtest'><td>tablist orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-209'><td><a href='http://www.w3c-test.org/wai-aria/tablist_orientation_vertical-manual.html' target='_blank'>/wai-aria/tablist_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-209-0' class='subtest'><td>tablist orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-210'><td><a href='http://www.w3c-test.org/wai-aria/term_role-manual.html' target='_blank'>/wai-aria/term_role-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-210-0' class='subtest'><td>term role</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-211'><td><a href='http://www.w3c-test.org/wai-aria/textbox_placeholder-manual.html' target='_blank'>/wai-aria/textbox_placeholder-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-211-0' class='subtest'><td>textbox placeholder</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains placeholder-text:DD/MM/YYYY" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'placeholder:DD/MM/YYYY', 'margin-top:0px', 'xml-roles:textbox', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1303429">https://bugzil.la/1303429</a>: [NEW] expose placeholder object attribute for HTML placeholder <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXPlaceholderValue is DD/MM/YYYY" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTextField" failed <br />
 <strong>Actual value:</strong> AXTextArea <br />
@@ -2360,66 +3181,97 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <strong>Actual value:</strong> text entry area <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-212'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_horizontal-manual.html' target='_blank'>/wai-aria/toolbar_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-212-0' class='subtest'><td>toolbar orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-213'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/toolbar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-213-0' class='subtest'><td>toolbar orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-214'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_vertical-manual.html' target='_blank'>/wai-aria/toolbar_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-214-0' class='subtest'><td>toolbar orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-215'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_horizontal-manual.html' target='_blank'>/wai-aria/tree_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-215-0' class='subtest'><td>tree orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-216'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_unspecified-manual.html' target='_blank'>/wai-aria/tree_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-216-0' class='subtest'><td>tree orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-217'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_vertical-manual.html' target='_blank'>/wai-aria/tree_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-217-0' class='subtest'><td>tree orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-218'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_colcount_8-manual.html' target='_blank'>/wai-aria/treegrid_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-218-0' class='subtest'><td>treegrid colcount 8</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
+<tr class='test' id='test-file-212'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_horizontal-manual.html' target='_blank'>/wai-aria/toolbar_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-212-0' class='subtest'><td>toolbar orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-213'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_unspecified-manual.html' target='_blank'>/wai-aria/toolbar_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-213-0' class='subtest'><td>toolbar orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-214'><td><a href='http://www.w3c-test.org/wai-aria/toolbar_orientation_vertical-manual.html' target='_blank'>/wai-aria/toolbar_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-214-0' class='subtest'><td>toolbar orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-215'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_horizontal-manual.html' target='_blank'>/wai-aria/tree_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-215-0' class='subtest'><td>tree orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-216'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_unspecified-manual.html' target='_blank'>/wai-aria/tree_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-216-0' class='subtest'><td>tree orientation unspecified</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-217'><td><a href='http://www.w3c-test.org/wai-aria/tree_orientation_vertical-manual.html' target='_blank'>/wai-aria/tree_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-217-0' class='subtest'><td>tree orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-218'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_colcount_8-manual.html' target='_blank'>/wai-aria/treegrid_colcount_8-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-218-0' class='subtest'><td>treegrid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-219'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_horizontal-manual.html' target='_blank'>/wai-aria/treegrid_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-219-0' class='subtest'><td>treegrid orientation horizontal</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-220'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_unspecified-manual.html' target='_blank'>/wai-aria/treegrid_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-220-0' class='subtest'><td>treegrid orientation unspecified</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_VERTICAL" failed <br />
-<strong>Actual value:</strong> ['STATE_EDITABLE', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE'] <br />
-<a href="https://bugzil.la/1357042">https://bugzil.la/1357042</a>: [NEW] Implement or update support for exposure of aria-orientation via ATK StateSet <br />
+<tr class='test' id='test-file-219'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_horizontal-manual.html' target='_blank'>/wai-aria/treegrid_orientation_horizontal-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-219-0' class='subtest'><td>treegrid orientation horizontal</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXHorizontalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-221'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_vertical-manual.html' target='_blank'>/wai-aria/treegrid_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-221-0' class='subtest'><td>treegrid orientation vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-222'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_rowcount_3-manual.html' target='_blank'>/wai-aria/treegrid_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-222-0' class='subtest'><td>treegrid rowcount 3</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
+<tr class='test' id='test-file-220'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_unspecified-manual.html' target='_blank'>/wai-aria/treegrid_orientation_unspecified-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-220-0' class='subtest'><td>treegrid orientation unspecified</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-221'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_orientation_vertical-manual.html' target='_blank'>/wai-aria/treegrid_orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-221-0' class='subtest'><td>treegrid orientation vertical</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOrientation is AXVerticalOrientation" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-222'><td><a href='http://www.w3c-test.org/wai-aria/treegrid_rowcount_3-manual.html' target='_blank'>/wai-aria/treegrid_rowcount_3-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-222-0' class='subtest'><td>treegrid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowCount is 3" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-223'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_false-manual.html' target='_blank'>/wai-aria/treeitem_selected_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-223-0' class='subtest'><td>treeitem selected false</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE<em>TREE</em>ITEM" failed <br />
-<strong>Actual value:</strong> ROLE_LIST_ITEM <br />
-<a href="https://bugzil.la/1355423">https://bugzil.la/1355423</a>: [NEW] ARIA treeitem role should be mapped as ATK_ROLE_TREE_ITEM; not ATK_ROLE_LIST_ITEM <br />
+<tr class='test' id='test-file-223'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_false-manual.html' target='_blank'>/wai-aria/treeitem_selected_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-223-0' class='subtest'><td>treeitem selected false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSelected is false" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is outline row" failed <br />
 <strong>Actual value:</strong> row <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-224'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_true-manual.html' target='_blank'>/wai-aria/treeitem_selected_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-224-0' class='subtest'><td>treeitem selected true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE<em>TREE</em>ITEM" failed <br />
-<strong>Actual value:</strong> ROLE_LIST_ITEM <br />
-<a href="https://bugzil.la/1355423">https://bugzil.la/1355423</a>: [NEW] ARIA treeitem role should be mapped as ATK_ROLE_TREE_ITEM; not ATK_ROLE_LIST_ITEM <br />
+<tr class='test' id='test-file-224'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_true-manual.html' target='_blank'>/wai-aria/treeitem_selected_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-224-0' class='subtest'><td>treeitem selected true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSelected is true" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is outline row" failed <br />
 <strong>Actual value:</strong> row <br />
@@ -2427,33 +3279,35 @@ https://bugzilla.gnome.org/show_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 i
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-225'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_undefined-manual.html' target='_blank'>/wai-aria/treeitem_selected_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-225-0' class='subtest'><td>treeitem selected undefined</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property role is ROLE<em>TREE</em>ITEM" failed <br />
-<strong>Actual value:</strong> ROLE_LIST_ITEM <br />
-<a href="https://bugzil.la/1355423">https://bugzil.la/1355423</a>: [NEW] ARIA treeitem role should be mapped as ATK_ROLE_TREE_ITEM; not ATK_ROLE_LIST_ITEM <br />
+<tr class='test' id='test-file-225'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_undefined-manual.html' target='_blank'>/wai-aria/treeitem_selected_undefined-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-225-0' class='subtest'><td>treeitem selected undefined</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSelected is false" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRoleDescription is outline row" failed <br />
 <strong>Actual value:</strong> row <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-226'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_value_changes-manual.html' target='_blank'>/wai-aria/treeitem_selected_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-226-0' class='subtest'><td>treeitem selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
+<tr class='test' id='test-file-226'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_value_changes-manual.html' target='_blank'>/wai-aria/treeitem_selected_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-226-0' class='subtest'><td>treeitem selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-226-1' class='subtest'><td>treeitem selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
+<tr id='subtest-226-1' class='subtest'><td>treeitem selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:selection-changed" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-226-2' class='subtest'><td>treeitem selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
+<tr id='subtest-226-2' class='subtest'><td>treeitem selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
 

--- a/wai-aria/complete-fails.html
+++ b/wai-aria/complete-fails.html
@@ -12,26 +12,23 @@
         <h1>WAI ARIA 1.1: Complete Failures</h1>
       </header>
       
-      <p><strong>Completely failed files</strong>: 38; <strong>Completely failed subtests</strong>: 12; <strong>Failure level</strong>: 12/252 (4.76%)</p>
+      <p><strong>Completely failed files</strong>: 38; <strong>Completely failed subtests</strong>: 4; <strong>Failure level</strong>: 4/252 (1.59%)</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/wai-aria/application_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
 <li><a href='#test-file-1'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-2'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
-<li><a href='#test-file-3'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
-<li><a href='#test-file-4'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
-<li><a href='#test-file-5'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
-<li><a href='#test-file-6'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-7'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-2'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-3'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant-manual.html' target='_blank'>/wai-aria/application_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-2-1' class='subtest'><td>application activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>FF02</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant-manual.html' target='_blank'>/wai-aria/application_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-2-1' class='subtest'><td>application activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
@@ -47,17 +44,19 @@
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-3-1' class='subtest'><td>application activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-3-1' class='subtest'><td>application activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
@@ -72,119 +71,19 @@
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-13-0' class='subtest'><td>aria-details pointing to details element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
-<strong>Actual value:</strong> None <br />
-ERROR: Object not found <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165842">https://webkit.org/b/165842</a> <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr id='subtest-13-1' class='subtest'><td>aria-details pointing to details element 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-14-0' class='subtest'><td>aria-details pointing to div element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
-<strong>Actual value:</strong> None <br />
-ERROR: Object not found <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165842">https://webkit.org/b/165842</a> <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr id='subtest-14-1' class='subtest'><td>aria-details pointing to div element 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-77-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr id='subtest-77-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-78-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr id='subtest-78-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -201,17 +100,19 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> None <br />

--- a/wai-aria/consolidated.json
+++ b/wai-aria/consolidated.json
@@ -1,6 +1,7 @@
 {
   "ua": [
     "FF01",
+    "FF02",
     "GC02",
     "WK01",
     "WK02"
@@ -9,40 +10,44 @@
     "/wai-aria/alertdialog_modal_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "alertdialog modal false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web alert dialog\" failed   \n**Actual value:** alert dialog  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRoleDescription is web alert dialog\" failed   \n**Actual value:** alertdialog  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         },
         "alertdialog modal false 1": {
           "stNum": 1,
           "byUA": {
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {},
           "totals": {
-            "PASS": 2
+            "PASS": 3
           }
         }
       }
@@ -50,42 +55,47 @@
     "/wai-aria/alertdialog_modal_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "alertdialog modal true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web alert dialog\" failed   \n**Actual value:** alert dialog  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRoleDescription is web alert dialog\" failed   \n**Actual value:** alertdialog  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         },
         "alertdialog modal true 1": {
           "stNum": 1,
           "byUA": {
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false",
             "GC02": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
+            "FAIL": 2,
             "PASS": 1
           }
         }
@@ -94,49 +104,54 @@
     "/wai-aria/application_activedescendant-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "application activedescendant": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXWebApplication\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is web application\" failed   \n**Actual value:** group  \n;  expected true got false",
             "GC02": "assert_true: \"property AXSubrole is AXWebApplication\" failed   \n**Actual value:** AXLandmarkApplication  \n; \"property AXRoleDescription is web application\" failed   \n**Actual value:** application  \n;  expected true got false",
             "WK01": "assert\\_true: \"property states doesNotContain STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_FOCUSED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE']  \n;  expected true got false",
             "WK02": "assert_true: \"property AXFocused is false\" failed   \n**Actual value:** true  \n;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         },
         "application activedescendant 1": {
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false",
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "WK01": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE']  \n;  expected true got false",
             "WK02": "assert_true: \"property AXFocused is true\" failed   \n**Actual value:** false  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4
+            "FAIL": 5
           }
         }
       }
@@ -144,49 +159,54 @@
     "/wai-aria/application_activedescendant_value_changes-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "application activedescendant value changes": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXWebApplication\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is web application\" failed   \n**Actual value:** group  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"property AXSubrole is AXWebApplication\" failed   \n**Actual value:** AXLandmarkApplication  \n; \"property AXRoleDescription is web application\" failed   \n**Actual value:** application  \n; \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false",
             "WK01": "assert\\_true: \"property states doesNotContain STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_FOCUSED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE']  \n;  expected true got false",
             "WK02": "assert_true: \"property AXFocused is false\" failed   \n**Actual value:** true  \n; \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         },
         "application activedescendant value changes 1": {
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false",
-            "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false",
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false",
+            "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false",
             "WK01": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE']  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false",
             "WK02": "assert_true: \"property AXFocused is true\" failed   \n**Actual value:** false  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4
+            "FAIL": 5
           }
         }
       }
@@ -194,29 +214,32 @@
     "/wai-aria/aria-current_not_declared-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current not declared": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXARIACurrent is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent is false\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -224,29 +247,32 @@
     "/wai-aria/aria-current_with_value_changes-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current with value changes": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"event type is object:state-changed:active\" failed <https://bugzil.la/1355921>  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIACurrent contains false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent contains false\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -255,29 +281,32 @@
     "/wai-aria/aria-current_with_value_date-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current with value date": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property states contains STATE\\_ACTIVE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SELECTABLE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355921>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK\\_STATE\\_ACTIVE  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXARIACurrent is date\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent is date\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -286,29 +315,32 @@
     "/wai-aria/aria-current_with_value_location-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current with value location": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property states contains STATE\\_ACTIVE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355921>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK\\_STATE\\_ACTIVE  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIACurrent is location\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent is location\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -317,29 +349,32 @@
     "/wai-aria/aria-current_with_value_page-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current with value page": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property states contains STATE\\_ACTIVE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355921>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK\\_STATE\\_ACTIVE  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIACurrent is page\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent is page\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -348,29 +383,32 @@
     "/wai-aria/aria-current_with_value_step-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current with value step": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property states contains STATE\\_ACTIVE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355921>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK\\_STATE\\_ACTIVE  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIACurrent is step\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent is step\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -379,29 +417,32 @@
     "/wai-aria/aria-current_with_value_time-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current with value time": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property states contains STATE\\_ACTIVE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SELECTABLE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355921>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK\\_STATE\\_ACTIVE  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXARIACurrent is time\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent is time\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -410,29 +451,32 @@
     "/wai-aria/aria-current_with_value_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current with value true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property states contains STATE\\_ACTIVE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355921>: [NEW] Elements with a defined, non-false value for aria-current should expose ATK\\_STATE\\_ACTIVE  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIACurrent is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent is true\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -441,29 +485,32 @@
     "/wai-aria/aria-current_with_value_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-current with value unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXARIACurrent is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIACurrent is false\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -471,45 +518,48 @@
     "/wai-aria/aria-details_pointing_to_details_element-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-details pointing to details element": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"relation RELATION\\_DETAILS is details\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types  \n;  expected true got false",
+            "FF02": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false",
-            "WK01": "assert\\_true: \"relation RELATION\\_DETAILS is details\" failed   \n**Actual value:** None  \nERROR: Object not found  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types  \n;  expected true got false",
+            "WK01": "assert\\_true: \"relation RELATION\\_DETAILS is [details]\" failed   \n**Actual value:** None  \nERROR: Object not found  \n;  expected true got false",
             "WK02": "assert_true: \"property TBD is TBD\" failed <https://webkit.org/b/165842>  \n;  expected true got false"
           },
           "totals": {
+            "PASS": 1,
             "FAIL": 4
           }
         },
         "aria-details pointing to details element 1": {
           "stNum": 1,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
             "WK01": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types  \n;  expected true got false",
-            "WK01": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types  \n;  expected true got false"
+            "WK01": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 1,
+            "FAIL": 1
           }
         }
       }
@@ -517,45 +567,48 @@
     "/wai-aria/aria-details_pointing_to_div_element-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "aria-details pointing to div element": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"relation RELATION\\_DETAILS is details\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types  \n;  expected true got false",
+            "FF02": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false",
-            "WK01": "assert\\_true: \"relation RELATION\\_DETAILS is details\" failed   \n**Actual value:** None  \nERROR: Object not found  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types  \n;  expected true got false",
+            "WK01": "assert\\_true: \"relation RELATION\\_DETAILS is [details]\" failed   \n**Actual value:** None  \nERROR: Object not found  \n;  expected true got false",
             "WK02": "assert_true: \"property TBD is TBD\" failed <https://webkit.org/b/165842>  \n;  expected true got false"
           },
           "totals": {
+            "PASS": 1,
             "FAIL": 4
           }
         },
         "aria-details pointing to div element 1": {
           "stNum": 1,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
             "WK01": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types  \n;  expected true got false",
-            "WK01": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types  \n;  expected true got false"
+            "WK01": "assert\\_true: \"relation RELATION\\_DETAILS_FOR is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 1,
+            "FAIL": 1
           }
         }
       }
@@ -563,30 +616,32 @@
     "/wai-aria/article_in_feed_posinset_and_setsize-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "article in feed posinset and setsize": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property role is ROLE_ARTICLE\" failed   \n**Actual value:** ROLE\\_DOCUMENT\\_FRAME  \n<https://bugzil.la/1305446>: [NEW] Expose ARIA \"article\" role as ROLE\\_ARTICLE and \"log\" role as ROLE\\_LOG  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** 0  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** 0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
-            "PASS": 2
+            "PASS": 3,
+            "FAIL": 2
           }
         }
       }
@@ -594,29 +649,32 @@
     "/wai-aria/article_in_feed_setsize_-1-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "article in feed setsize -1": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property role is ROLE_ARTICLE\" failed   \n**Actual value:** ROLE\\_DOCUMENT\\_FRAME  \n<https://bugzil.la/1305446>: [NEW] Expose ARIA \"article\" role as ROLE\\_ARTICLE and \"log\" role as ROLE\\_LOG  \n; \"property objectAttributes contains setsize:-1\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:article', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1358473>: [NEW] Do not calculate setsize when aria-setsize has a value of -1  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains setsize:-1\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:article', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1358473>: [NEW] Do not calculate setsize when aria-setsize has a value of -1  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIASetSize is -1\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIASetSize is -1\" failed   \n**Actual value:** 0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -625,30 +683,32 @@
     "/wai-aria/article_not_in_feed_posinset_and_setsize-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "article not in feed posinset and setsize": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property role is ROLE_ARTICLE\" failed   \n**Actual value:** ROLE\\_DOCUMENT\\_FRAME  \n<https://bugzil.la/1305446>: [NEW] Expose ARIA \"article\" role as ROLE\\_ARTICLE and \"log\" role as ROLE\\_LOG  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** 0  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** 0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
-            "PASS": 2
+            "PASS": 3,
+            "FAIL": 2
           }
         }
       }
@@ -656,29 +716,32 @@
     "/wai-aria/button_haspopup_dialog-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup dialog": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:dialog\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:dialog\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -687,30 +750,33 @@
     "/wai-aria/button_haspopup_emptystring-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup emptystring": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property objectAttributes contains haspopup:false\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
             "GC02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
             "WK02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -719,30 +785,33 @@
     "/wai-aria/button_haspopup_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
             "GC02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
             "WK02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
             "PASS": 2,
-            "FAIL": 2
+            "FAIL": 3
           }
         }
       }
@@ -750,30 +819,33 @@
     "/wai-aria/button_haspopup_foo-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup foo": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:false\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:false\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states doesNotContain STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_HAS\\_POPUP']  \n;  expected true got false",
+            "FF02": "assert_true: \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
             "GC02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
             "WK02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -782,29 +854,32 @@
     "/wai-aria/button_haspopup_grid-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup grid": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:grid\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:grid\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -813,29 +888,32 @@
     "/wai-aria/button_haspopup_listbox-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup listbox": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -844,29 +922,32 @@
     "/wai-aria/button_haspopup_menu-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup menu": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:menu\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:menu\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -875,29 +956,32 @@
     "/wai-aria/button_haspopup_tree-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup tree": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:tree\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n; \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:tree\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** button  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -906,29 +990,31 @@
     "/wai-aria/button_haspopup_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup true": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+            "FF02": "assert_true: \"property AXRole is AXPopUpButton\" failed   \n**Actual value:** AXMenuButton  \n; \"property AXRoleDescription is pop up button\" failed   \n**Actual value:** menu button  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** []  \n; \"property actions contains AXPress\" failed   \n**Actual value:** []  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
-            "PASS": 3
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -936,30 +1022,33 @@
     "/wai-aria/button_haspopup_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button haspopup unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
             "GC02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
             "WK02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress,  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
             "PASS": 2,
-            "FAIL": 2
+            "FAIL": 3
           }
         }
       }
@@ -967,19 +1056,21 @@
     "/wai-aria/button_roledescription_empty-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button roledescription empty": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -988,7 +1079,7 @@
             "GC02": "assert_true: \"property AXRoleDescription is button\" failed   \n**Actual value:**   \n;  expected true got false"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 4,
             "FAIL": 1
           }
         }
@@ -997,26 +1088,31 @@
     "/wai-aria/button_roledescription_valid-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button roledescription valid": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRoleDescription is SassyButton\" failed   \n**Actual value:** button  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -1024,19 +1120,21 @@
     "/wai-aria/button_roledescription_whitespace_only-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "button roledescription whitespace only": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -1045,7 +1143,7 @@
             "GC02": "assert_true: \"property AXRoleDescription is button\" failed   \n**Actual value:**       \n;  expected true got false"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 4,
             "FAIL": 1
           }
         }
@@ -1054,30 +1152,33 @@
     "/wai-aria/cell-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_columns() is 8\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_columns() is 8\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         },
@@ -1085,17 +1186,19 @@
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -1104,29 +1207,32 @@
     "/wai-aria/cell_aria-colspan_2_on_div-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-colspan 2 on div": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1135,29 +1241,32 @@
     "/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-colspan 2 on td html colspan 3": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property objectAttributes doesNotContain colspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'table-cell-index:0', 'tag:td', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px', 'colspan:2']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false",
-            "GC02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1166,19 +1275,21 @@
     "/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-colspan 2 on td html colspan 3 with headers and border": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -1188,7 +1299,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -1196,29 +1307,32 @@
     "/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-colspan 2 on td html colspan 3 with three actual columns": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -1226,29 +1340,32 @@
     "/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-colspan 2 on td with html colspan not specified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1257,29 +1374,32 @@
     "/wai-aria/cell_aria-rowspan_2_on_div-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-rowspan 2 on div": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1288,28 +1408,31 @@
     "/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-rowspan 2 on td html rowspan 3": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:cell', 'table-cell-index:0', 'tag:td', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property objectAttributes doesNotContain rowspan:2\" failed   \n**Actual value:** ['display:table-cell', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:cell', 'table-cell-index:0', 'tag:td', 'id:test', 'rowspan:2', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1357153>: [NEW] Ignore aria-{row,col}span values when host language {row,col}span attribute is present  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
+            "FAIL": 2,
             "PASS": 3
           }
         }
@@ -1318,29 +1441,32 @@
     "/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-rowspan 2 on td html rowspan 3 with three actual rows": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=3\" failed   \n**Actual value:** (row=1, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1349,29 +1475,32 @@
     "/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell aria-rowspan 2 on td with html rowspan not specified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1380,30 +1509,33 @@
     "/wai-aria/cell_colindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell colindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -1412,30 +1544,33 @@
     "/wai-aria/cell_rowindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "cell rowindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -1444,29 +1579,32 @@
     "/wai-aria/checkbox_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "checkbox readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -1474,19 +1612,21 @@
     "/wai-aria/checkbox_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "checkbox readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -1496,7 +1636,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -1504,29 +1644,32 @@
     "/wai-aria/checkbox_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "checkbox readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -1534,29 +1677,32 @@
     "/wai-aria/columnheader_aria-colspan_2_on_div-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader aria-colspan 2 on div": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1565,19 +1711,21 @@
     "/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader aria-colspan 2 on th html colspan 3": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -1587,7 +1735,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -1595,19 +1743,21 @@
     "/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader aria-colspan 2 on th html colspan 3 with three actual columns": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -1616,7 +1766,7 @@
             "GC02": "assert_true: \"property AXColumnIndexRange.length is 3\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 4,
             "FAIL": 1
           }
         }
@@ -1625,29 +1775,32 @@
     "/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader aria-colspan 2 on th with html colspan not specified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1656,29 +1809,32 @@
     "/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader aria-rowspan 2 on div": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1687,19 +1843,21 @@
     "/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader aria-rowspan 2 on th html rowspan 3": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -1709,7 +1867,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -1717,19 +1875,21 @@
     "/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -1740,7 +1900,7 @@
           },
           "totals": {
             "FAIL": 2,
-            "PASS": 2
+            "PASS": 3
           }
         }
       }
@@ -1748,29 +1908,32 @@
     "/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader aria-rowspan 2 on th with html rowspan not specified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -1779,30 +1942,33 @@
     "/wai-aria/columnheader_colindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader colindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -1811,30 +1977,33 @@
     "/wai-aria/columnheader_rowindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader rowindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -1843,29 +2012,32 @@
     "/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader selected false not automatically propagated": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is cell\" failed   \n**Actual value:** group  \n; \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXSelected is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -1873,26 +2045,31 @@
     "/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "columnheader selected true not automatically propagated": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is cell\" failed   \n**Actual value:** group  \n; \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -1900,29 +2077,28 @@
     "/wai-aria/combobox_controls_an_invalid_id-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox controls an invalid ID": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
-            "GC02": "FAIL",
+            "FF02": "PASS",
+            "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {
-            "GC02": "assert_true: \"property AXLinkedUIElements doesNotContain myID\" failed   \n**Actual value:** None  \n;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3,
-            "FAIL": 1
+            "PASS": 5
           }
         },
         "combobox controls an invalid ID 1": {
@@ -1941,30 +2117,33 @@
     "/wai-aria/combobox_haspopup_dialog-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox haspopup dialog": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:dialog\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:dialog\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n;  expected true got false",
             "WK02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -1973,30 +2152,34 @@
     "/wai-aria/combobox_haspopup_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox haspopup false": {
           "stNum": 0,
           "byUA": {
-            "FF01": "PASS",
+            "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "GC02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
-            "WK02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property states doesNotContain STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_HAS\\_POPUP']  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions doesNotContain AXPress\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
+            "GC02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false",
+            "WK02": "assert_true: \"property actions doesNotContain AXShowMenu\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "PASS": 2,
-            "FAIL": 2
+            "FAIL": 4,
+            "PASS": 1
           }
         }
       }
@@ -2004,30 +2187,33 @@
     "/wai-aria/combobox_haspopup_grid-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox haspopup grid": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:grid\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:grid\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n;  expected true got false",
             "WK02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -2036,30 +2222,33 @@
     "/wai-aria/combobox_haspopup_listbox-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox haspopup listbox": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n;  expected true got false",
             "WK02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -2068,30 +2257,33 @@
     "/wai-aria/combobox_haspopup_menu-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox haspopup menu": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:menu\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:menu\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n;  expected true got false",
             "WK02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -2100,30 +2292,33 @@
     "/wai-aria/combobox_haspopup_tree-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox haspopup tree": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:tree\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:tree\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n;  expected true got false",
             "WK02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -2132,31 +2327,33 @@
     "/wai-aria/combobox_haspopup_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox haspopup true": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n;  expected true got false",
             "WK02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "PASS": 2,
+            "FAIL": 3
           }
         }
       }
@@ -2164,30 +2361,33 @@
     "/wai-aria/combobox_haspopup_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox haspopup unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property objectAttributes contains haspopup:listbox\" failed   \n**Actual value:** ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355449>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXExpanded is true\" failed   \n**Actual value:** None  \n; \"property actions contains AXShowMenu\" failed   \n**Actual value:** (  \n    AXPress  \n)  \n;  expected true got false",
             "GC02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n;  expected true got false",
             "WK02": "assert_true: \"property actions contains AXPress\" failed   \n**Actual value:** (  \n    AXShowMenu,  \n    AXScrollToVisible  \n)  \n<https://github.com/w3c/aria/issues/570>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -2196,26 +2396,31 @@
     "/wai-aria/combobox_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -2223,30 +2428,32 @@
     "/wai-aria/combobox_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox orientation unspecified": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states doesNotContain STATE\\_VERTICAL\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1357042>: [NEW] Implement or update support for exposure of aria-orientation via ATK StateSet  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXOrientation is AXUnknownOrientation\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXOrientation is AXUnknownOrientation\" failed   \n**Actual value:** AXVerticalOrientation  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
-            "PASS": 2
+            "PASS": 3,
+            "FAIL": 2
           }
         }
       }
@@ -2254,26 +2461,31 @@
     "/wai-aria/combobox_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -2281,29 +2493,31 @@
     "/wai-aria/combobox_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox readonly false": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
-            "PASS": 3
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -2311,28 +2525,31 @@
     "/wai-aria/combobox_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n; \"property states contains STATE\\_READ_ONLY\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property states contains STATE\\_READ_ONLY\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_HAS\\_POPUP']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
+            "FAIL": 2,
             "PASS": 3
           }
         }
@@ -2341,29 +2558,31 @@
     "/wai-aria/combobox_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "combobox readonly unspecified": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_HAS_POPUP\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_EXPANDABLE', 'STATE\\_EXPANDED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1355447>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK\\_STATE\\_HAS\\_POPUP  \n;  expected true got false"
+            "FF02": "assert_true: \"property AXRole is AXComboBox\" failed   \n**Actual value:** AXPopUpButton  \n; \"property AXRoleDescription is combo box\" failed   \n**Actual value:** pop up button  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
-            "PASS": 3
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -2371,40 +2590,44 @@
     "/wai-aria/dialog_modal_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "dialog modal false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** window  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** dialog  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         },
         "dialog modal false 1": {
           "stNum": 1,
           "byUA": {
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {},
           "totals": {
-            "PASS": 2
+            "PASS": 3
           }
         }
       }
@@ -2412,42 +2635,47 @@
     "/wai-aria/dialog_modal_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "dialog modal true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** window  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** dialog  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         },
         "dialog modal true 1": {
           "stNum": 1,
           "byUA": {
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false",
             "GC02": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
+            "FAIL": 2,
             "PASS": 1
           }
         }
@@ -2456,40 +2684,44 @@
     "/wai-aria/dialog_modal_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "dialog modal unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** AXWindow  \n; \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** window  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRoleDescription is web dialog\" failed   \n**Actual value:** dialog  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         },
         "dialog modal unspecified 1": {
           "stNum": 1,
           "byUA": {
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {},
           "totals": {
-            "PASS": 2
+            "PASS": 3
           }
         }
       }
@@ -2497,19 +2729,21 @@
     "/wai-aria/div_element_without_role_roledescription_valid-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "div element without role roledescription valid": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "FAIL"
@@ -2519,7 +2753,7 @@
             "WK02": "assert_true: \"property AXRoleDescription is group\" failed   \n**Actual value:** foo  \n;  expected true got false"
           },
           "totals": {
-            "PASS": 2,
+            "PASS": 3,
             "FAIL": 2
           }
         }
@@ -2528,45 +2762,48 @@
     "/wai-aria/errormessage_object_in_invalid_state-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "errormessage object in invalid state": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE exists false\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types  \n;  expected true got false",
+            "FF02": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false",
-            "WK01": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE exists false\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types  \n;  expected true got false",
+            "WK01": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE is [error]\" failed   \n**Actual value:** []  \n;  expected true got false",
             "WK02": "assert_true: \"property TBD is TBD\" failed <https://webkit.org/b/165190>  \n;  expected true got false"
           },
           "totals": {
+            "PASS": 1,
             "FAIL": 4
           }
         },
         "errormessage object in invalid state 1": {
           "stNum": 1,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
             "WK01": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"relation RELATION\\_ERROR_FOR exists false\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types  \n;  expected true got false",
-            "WK01": "assert\\_true: \"relation RELATION\\_ERROR_FOR exists false\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types  \n;  expected true got false"
+            "WK01": "assert\\_true: \"relation RELATION\\_ERROR_FOR is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 1,
+            "FAIL": 1
           }
         }
       }
@@ -2574,45 +2811,48 @@
     "/wai-aria/errormessage_object_in_valid_state-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "errormessage object in valid state": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
-            "WK01": "FAIL",
+            "WK01": "PASS",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE is error\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property relations doesNotContain RELATION\\_ERROR_MESSAGE\" failed   \n**Actual value:** ['RELATION\\_LABELLED\\_BY', 'RELATION\\_ERROR\\_MESSAGE']  \n;  expected true got false",
+            "FF02": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"property TBD is TBD\" failed   \n;  expected true got false",
-            "WK01": "assert\\_true: \"relation RELATION\\_ERROR_MESSAGE is error\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types  \n;  expected true got false",
             "WK02": "assert_true: \"property TBD is TBD\" failed <https://webkit.org/b/165190>  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4
+            "FAIL": 4,
+            "PASS": 1
           }
         },
         "errormessage object in valid state 1": {
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
-            "WK01": "FAIL"
+            "WK01": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"relation RELATION\\_ERROR_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types  \n;  expected true got false",
-            "WK01": "assert\\_true: \"relation RELATION\\_ERROR_FOR is test\" failed   \n**Actual value:** []  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property relations doesNotContain RELATION\\_ERROR_FOR\" failed   \n**Actual value:** ['RELATION\\_ERROR\\_FOR']  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2
+            "FAIL": 1,
+            "PASS": 1
           }
         }
       }
@@ -2620,29 +2860,32 @@
     "/wai-aria/feed-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "feed": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is feed\" failed   \n**Actual value:** group  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXGroup\" failed   \n**Actual value:** None  \nERROR: Object not found  \n; \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \nERROR: Object not found  \n; \"property AXRoleDescription is feed\" failed   \n**Actual value:** None  \nERROR: Object not found  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -2650,28 +2893,31 @@
     "/wai-aria/figure-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "figure": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property role is ROLE_PANEL\" failed   \n**Actual value:** ROLE\\_SECTION  \n<https://bugzil.la/1356049>: [NEW] ARIA figure role should be mapped as ATK\\_ROLE\\_PANEL  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property role is ROLE_PANEL\" failed   \n**Actual value:** ROLE\\_SECTION  \n<https://bugzil.la/1356049>: [NEW] ARIA figure role should be mapped as ATK\\_ROLE\\_PANEL  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXApplicationGroup  \n; \"property AXRoleDescription is figure\" failed   \n**Actual value:** group  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
+            "FAIL": 2,
             "PASS": 3
           }
         }
@@ -2680,61 +2926,68 @@
     "/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid aria-readonly false automatically propagated": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         },
         "grid aria-readonly false automatically propagated 1": {
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         },
         "grid aria-readonly false automatically propagated 2": {
           "stNum": 2,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -2742,28 +2995,31 @@
     "/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid aria-readonly true automatically propagated": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_READ_ONLY\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SELECTABLE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property states contains STATE\\_READ_ONLY\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SELECTABLE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
+            "FAIL": 2,
             "PASS": 3
           }
         },
@@ -2771,6 +3027,7 @@
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -2780,13 +3037,14 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         },
         "grid aria-readonly true automatically propagated 2": {
           "stNum": 2,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -2796,7 +3054,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -2804,29 +3062,32 @@
     "/wai-aria/grid_busy_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid busy false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTable\" failed   \n**Actual value:** AXGrid  \n; \"property AXRoleDescription is table\" failed   \n**Actual value:** grid  \n; \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -2834,29 +3095,32 @@
     "/wai-aria/grid_busy_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid busy true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTable\" failed   \n**Actual value:** AXGrid  \n; \"property AXRoleDescription is table\" failed   \n**Actual value:** grid  \n; \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -2864,29 +3128,32 @@
     "/wai-aria/grid_busy_value_changes-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid busy value changes": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRoleDescription is table\" failed   \n**Actual value:** None  \n; \"property AXElementBusy is true\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"event type is AXElementBusyChanged\" failed   \n**Actual value:** AXGrid  \n; \"property AXSubrole is <nil>\" failed   \n**Actual value:** grid  \n; \"property AXRoleDescription is table\" failed   \n**Actual value:** None  \n; \"property AXElementBusy is true\" failed   \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -2894,30 +3161,33 @@
     "/wai-aria/grid_colcount_8-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid colcount 8": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_columns() is 8\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTable\" failed   \n**Actual value:** AXGrid  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_columns() is 8\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -2926,29 +3196,32 @@
     "/wai-aria/grid_columnheader_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid columnheader readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -2956,19 +3229,21 @@
     "/wai-aria/grid_columnheader_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid columnheader readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -2978,7 +3253,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -2986,29 +3261,32 @@
     "/wai-aria/grid_columnheader_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid columnheader readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3016,26 +3294,31 @@
     "/wai-aria/grid_columnheader_required_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid columnheader required false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRequired is false\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3043,26 +3326,31 @@
     "/wai-aria/grid_columnheader_required_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid columnheader required true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRequired is true\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3070,26 +3358,31 @@
     "/wai-aria/grid_columnheader_required_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid columnheader required unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRequired is false\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3097,30 +3390,33 @@
     "/wai-aria/grid_rowcount_3-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid rowcount 3": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_rows() is 3\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIARowCount is 3\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTable\" failed   \n**Actual value:** AXGrid  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_rows() is 3\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -3129,29 +3425,32 @@
     "/wai-aria/grid_rowheader_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid rowheader readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3159,19 +3458,21 @@
     "/wai-aria/grid_rowheader_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid rowheader readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -3181,7 +3482,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -3189,29 +3490,32 @@
     "/wai-aria/grid_rowheader_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid rowheader readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3219,26 +3523,31 @@
     "/wai-aria/grid_rowheader_required_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid rowheader required false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRequired is false\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3246,26 +3555,31 @@
     "/wai-aria/grid_rowheader_required_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid rowheader required true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRequired is true\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3273,26 +3587,31 @@
     "/wai-aria/grid_rowheader_required_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "grid rowheader required unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRequired is false\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3300,29 +3619,32 @@
     "/wai-aria/gridcell_aria-colspan_2_on_div-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "gridcell aria-colspan 2 on div": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -3331,29 +3653,32 @@
     "/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "gridcell aria-rowspan 2 on div": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -3362,29 +3687,32 @@
     "/wai-aria/gridcell_colindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "gridcell colindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -3393,29 +3721,32 @@
     "/wai-aria/gridcell_rowindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "gridcell rowindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -3424,26 +3755,28 @@
     "/wai-aria/group_hidden_undefined_element_not_rendered-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "group hidden undefined element not rendered": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {},
           "totals": {
-            "PASS": 4
+            "PASS": 5
           }
         }
       }
@@ -3451,29 +3784,32 @@
     "/wai-aria/group_hidden_undefined_element_rendered-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "group hidden undefined element rendered": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3481,29 +3817,32 @@
     "/wai-aria/heading_level_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "heading level unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property objectAttributes contains level:2\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:heading', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1357100>: [NEW] Implement support for implicit value for aria-level on heading role  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRoleDescription is heading\" failed   \n**Actual value:** AXHeading  \n; \"property AXValue is 2\" failed   \n**Actual value:** 0  \n;  expected true got false",
             "GC02": "assert_true: \"property AXValue is 2\" failed   \n**Actual value:**   \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -3512,31 +3851,34 @@
     "/wai-aria/keyshortcuts_multiple_shortcuts-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "keyshortcuts multiple shortcuts": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n;  expected true got false",
             "GC02": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n;  expected true got false",
             "WK01": "assert\\_true: \"property objectAttributes contains keyshortcuts:Shift+Space Alt+Space\" failed   \n**Actual value:** ['computed-role:button', 'xml-roles:button', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk']  \n<https://webkit.org/b/171175>: [NEW] [ATK] Expose value of aria-keyshortcuts as object attribute  \n;  expected true got false",
             "WK02": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n<https://webkit.org/b/159215>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts  \n;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         }
       }
@@ -3544,31 +3886,34 @@
     "/wai-aria/keyshortcuts_one_shortcut-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "keyshortcuts one shortcut": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n;  expected true got false",
             "GC02": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n;  expected true got false",
             "WK01": "assert\\_true: \"property objectAttributes contains keyshortcuts:Shift+Space\" failed   \n**Actual value:** ['computed-role:button', 'xml-roles:button', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk']  \n<https://webkit.org/b/171175>: [NEW] [ATK] Expose value of aria-keyshortcuts as object attribute  \n;  expected true got false",
             "WK02": "assert_true: \"result The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is true\" failed   \n**Actual value:** None  \nERROR: The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts is not supported  \nERROR: 'NoneType' object is not callable  \n<https://webkit.org/b/159215>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts  \n;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         }
       }
@@ -3576,29 +3921,32 @@
     "/wai-aria/listbox_busy_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listbox busy false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3606,29 +3954,32 @@
     "/wai-aria/listbox_busy_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listbox busy true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3636,26 +3987,31 @@
     "/wai-aria/listbox_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listbox orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3663,26 +4019,31 @@
     "/wai-aria/listbox_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listbox orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3690,26 +4051,31 @@
     "/wai-aria/listbox_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listbox orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3717,29 +4083,32 @@
     "/wai-aria/listbox_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listbox readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3747,19 +4116,21 @@
     "/wai-aria/listbox_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listbox readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -3769,7 +4140,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -3777,29 +4148,32 @@
     "/wai-aria/listbox_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listbox readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3807,30 +4181,32 @@
     "/wai-aria/listitem_setsize_-1-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "listitem setsize -1": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
-            "GC02": "FAIL",
+            "FF02": "FAIL",
+            "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property objectAttributes contains setsize:-1\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'posinset:1', 'margin-top:0px', 'xml-roles:listitem', 'tag:div', 'id:test', 'setsize:1', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1358473>: [NEW] Do not calculate setsize when aria-setsize has a value of -1  \n;  expected true got false",
-            "GC02": "assert_true: \"property AXARIASetSize is -1\" failed   \n**Actual value:** 1  \n;  expected true got false"
+            "FF02": "assert_true: \"property AXARIASetSize is -1\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "FAIL": 2,
-            "PASS": 2
+            "PASS": 3
           }
         }
       }
@@ -3838,26 +4214,31 @@
     "/wai-aria/menu_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menu orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3865,26 +4246,31 @@
     "/wai-aria/menu_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menu orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3892,26 +4278,31 @@
     "/wai-aria/menu_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menu orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -3919,29 +4310,32 @@
     "/wai-aria/menubar_busy_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menubar busy false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXElementBusy is false\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3949,29 +4343,32 @@
     "/wai-aria/menubar_busy_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menubar busy true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXElementBusy is true\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -3979,26 +4376,31 @@
     "/wai-aria/menubar_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menubar orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -4006,26 +4408,31 @@
     "/wai-aria/menubar_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menubar orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -4033,26 +4440,31 @@
     "/wai-aria/menubar_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menubar orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -4060,26 +4472,31 @@
     "/wai-aria/menuitem_posinset_and_setsize-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitem posinset and setsize": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -4087,29 +4504,32 @@
     "/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitemcheckbox posinset and setsize": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXValue is 1\" failed   \n**Actual value:**   \n; \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** 0  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** 0  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4117,29 +4537,32 @@
     "/wai-aria/menuitemcheckbox_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitemcheckbox readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4147,19 +4570,21 @@
     "/wai-aria/menuitemcheckbox_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitemcheckbox readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -4169,7 +4594,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -4177,29 +4602,32 @@
     "/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitemcheckbox readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4207,29 +4635,32 @@
     "/wai-aria/menuitemradio_posinset_and_setsize-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitemradio posinset and setsize": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXValue is 0\" failed   \n**Actual value:**   \n; \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAPosInSet is 4\" failed   \n**Actual value:** 0  \n; \"property AXARIASetSize is 8\" failed   \n**Actual value:** 0  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4237,29 +4668,32 @@
     "/wai-aria/menuitemradio_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitemradio readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4267,19 +4701,21 @@
     "/wai-aria/menuitemradio_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitemradio readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -4289,7 +4725,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -4297,29 +4733,32 @@
     "/wai-aria/menuitemradio_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "menuitemradio readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4327,26 +4766,28 @@
     "/wai-aria/none-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "none": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {},
           "totals": {
-            "PASS": 4
+            "PASS": 5
           }
         }
       }
@@ -4354,29 +4795,32 @@
     "/wai-aria/option_selected_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "option selected false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"property states contains STATE\\_SELECTABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE']  \n<https://webkit.org/b/171186>: [NEW] [ATK] Options in an ARIA listbox should have STATE\\_SELECTABLE and emit selection-related events  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4384,30 +4828,33 @@
     "/wai-aria/option_selected_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "option selected true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXSelected is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "WK01": "assert\\_true: \"property states contains STATE\\_SELECTABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_HORIZONTAL', 'STATE\\_SELECTED', 'STATE\\_SENSITIVE']  \n<https://webkit.org/b/171186>: [NEW] [ATK] Options in an ARIA listbox should have STATE\\_SELECTABLE and emit selection-related events  \n;  expected true got false"
           },
           "totals": {
             "PASS": 2,
-            "FAIL": 2
+            "FAIL": 3
           }
         }
       }
@@ -4415,29 +4862,32 @@
     "/wai-aria/option_selected_undefined-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "option selected undefined": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"property states contains STATE\\_SELECTABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE']  \n<https://webkit.org/b/171186>: [NEW] [ATK] Options in an ARIA listbox should have STATE\\_SELECTABLE and emit selection-related events  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4445,49 +4895,54 @@
     "/wai-aria/option_selected_value_changes-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "option selected value changes": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false",
             "WK01": "assert\\_true: \"event type is object:state-changed:selected\" failed <https://webkit.org/b/171186>  \n;  expected true got false",
             "WK02": "assert_true: \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         },
         "option selected value changes 1": {
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
             "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
             "WK01": "assert\\_true: \"event type is object:selection-changed\" failed <https://webkit.org/b/171186>  \n;  expected true got false",
             "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         },
         "option selected value changes 2": {
@@ -4509,26 +4964,31 @@
     "/wai-aria/radiogroup_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "radiogroup orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -4536,29 +4996,32 @@
     "/wai-aria/radiogroup_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "radiogroup orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXUnknownOrientation\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXOrientation is AXUnknownOrientation\" failed   \n**Actual value:**   \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4566,26 +5029,31 @@
     "/wai-aria/radiogroup_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "radiogroup orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -4593,29 +5061,32 @@
     "/wai-aria/radiogroup_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "radiogroup readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4623,19 +5094,21 @@
     "/wai-aria/radiogroup_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "radiogroup readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -4645,7 +5118,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -4653,29 +5126,32 @@
     "/wai-aria/radiogroup_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "radiogroup readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4683,29 +5159,32 @@
     "/wai-aria/region_with_name-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "region with name": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property role is ROLE_LANDMARK\" failed   \n**Actual value:** ROLE\\_PANEL  \n<https://bugzil.la/1210630>: [NEW] Section elements with accessible names should be mapped the same as ARIA role region  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** AXDocumentRegion  \n;  expected true got false",
             "GC02": "assert_true: \"property AXSubrole is AXLandmarkRegion\" failed   \n**Actual value:** AXDocumentRegion  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -4714,29 +5193,32 @@
     "/wai-aria/region_without_name-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "region without name": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property role is ROLE_SECTION\" failed   \n**Actual value:** ROLE\\_PANEL  \n<https://bugzil.la/1358462>: [NEW] Elements with role=\"region\" and no accessible name should be mapped according to host language  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXDocumentRegion  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** region  \n;  expected true got false",
             "GC02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXDocumentRegion  \n; \"property AXRoleDescription is group\" failed   \n**Actual value:** region  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -4745,19 +5227,21 @@
     "/wai-aria/row_colindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "row colindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "PASS"
@@ -4766,7 +5250,7 @@
             "WK01": "assert\\_true: \"property objectAttributes contains colindex:4\" failed   \n**Actual value:** ['computed-role:row', 'xml-roles:row', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk']  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 4,
             "FAIL": 1
           }
         },
@@ -4774,17 +5258,19 @@
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -4793,19 +5279,21 @@
     "/wai-aria/row_rowindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "row rowindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "PASS"
@@ -4814,7 +5302,7 @@
             "WK01": "assert\\_true: \"property objectAttributes contains rowindex:4\" failed   \n**Actual value:** ['computed-role:row', 'xml-roles:row', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk']  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "PASS": 3,
+            "PASS": 4,
             "FAIL": 1
           }
         },
@@ -4822,17 +5310,19 @@
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -4841,29 +5331,32 @@
     "/wai-aria/rowheader_aria-colspan_2_on_div-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "rowheader aria-colspan 2 on div": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains column_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXColumnIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -4872,29 +5365,32 @@
     "/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "rowheader aria-rowspan 2 on div": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_row_column_span() contains row_span=2\" failed   \n**Actual value:** (row=0, column=0, row\\_span=1, column\\_span=1)  \n<https://bugzil.la/1357013>: [NEW] atk\\_table\\_cell\\_get\\_row\\_column\\_span() should report the values of aria-rowspan and aria-colspan  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** 1  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRowIndexRange.length is 2\" failed   \n**Actual value:** None  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -4903,30 +5399,33 @@
     "/wai-aria/rowheader_colindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "rowheader colindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAColumnIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains column=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -4935,30 +5434,33 @@
     "/wai-aria/rowheader_rowindex_4-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "rowheader rowindex 4": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://bugzil.la/1357188>: [NEW] atk\\_table\\_cell\\_get\\_position() should report the values of aria-rowindex and aria-colindex  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIARowIndex is 4\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_cell_get_position() contains row=3\" failed   \n**Actual value:** (1, row=0, column=0)  \n<https://webkit.org/b/171176>: [NEW] [ATK] atk\\_table\\_cell\\_get\\_position() should return values of aria-rowindex and aria-colindex, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -4967,29 +5469,32 @@
     "/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "rowheader selected false not automatically propagated": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is cell\" failed   \n**Actual value:** group  \n; \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXSelected is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -4997,26 +5502,31 @@
     "/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "rowheader selected true not automatically propagated": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRole is AXCell\" failed   \n**Actual value:** AXGroup  \n; \"property AXRoleDescription is cell\" failed   \n**Actual value:** group  \n; \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5024,29 +5534,32 @@
     "/wai-aria/scrollbar_all_values_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "scrollbar all values unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_value_get_minimum_value() is 0\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1357071>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles  \n; \"result atk_value_get_current_value() is 50\" failed   \n**Actual value:** 0.0  \n<https://bugzil.la/1357071>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles  \n; \"result atk_value_get_maximum_value() is 100\" failed   \n**Actual value:** 0.0  \n<https://bugzil.la/1357071>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:** 0.0  \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -5055,29 +5568,32 @@
     "/wai-aria/scrollbar_only_valuenow_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "scrollbar only valuenow unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_value_get_current_value() is 20\" failed   \n**Actual value:** 0.0  \n<https://bugzil.la/1357071>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 20\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 40\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXValue is 20\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -5086,26 +5602,31 @@
     "/wai-aria/scrollbar_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "scrollbar orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5113,29 +5634,32 @@
     "/wai-aria/searchbox-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTextField\" failed   \n**Actual value:** AXTextArea  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -5143,48 +5667,53 @@
     "/wai-aria/searchbox_activedescendant-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox activedescendant": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false",
             "WK01": "assert\\_true: \"property states doesNotContain STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_EDITABLE', 'STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_FOCUSED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_SINGLE\\_LINE', 'STATE\\_VISIBLE']  \n;  expected true got false",
             "WK02": "assert_true: \"property AXFocused is false\" failed   \n**Actual value:** true  \n;  expected true got false"
           },
           "totals": {
             "PASS": 2,
-            "FAIL": 2
+            "FAIL": 3
           }
         },
         "searchbox activedescendant 1": {
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false",
-            "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false",
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false",
+            "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false",
             "WK01": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** None  \nERROR: Object not found  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** None  \nERROR: Object not found  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false",
             "WK02": "assert_true: \"property AXFocused is true\" failed   \n**Actual value:** false  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4
+            "FAIL": 5
           }
         }
       }
@@ -5192,49 +5721,54 @@
     "/wai-aria/searchbox_activedescendant_value_changes-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox activedescendant value changes": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"event type is AXSelectedChildrenChanged\" failed   \n**Actual value:** false  \n; \"result array isNot true\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"result array isNot true\" failed   \n;  expected true got false",
             "WK01": "assert\\_true: \"property states doesNotContain STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_EDITABLE', 'STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_FOCUSED', 'STATE\\_HORIZONTAL', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_SINGLE\\_LINE', 'STATE\\_VISIBLE']  \n;  expected true got false",
             "WK02": "assert_true: \"property AXFocused is false\" failed   \n**Actual value:** true  \n; \"result array isNot true\" failed   \n;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         },
         "searchbox activedescendant value changes 1": {
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false",
-            "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
+            "FF01": "assert\\_true: \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_FOCUSED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT']  \n<https://bugzil.la/1359045>: [NEW] A container's active descendant should expose ATK\\_STATE\\_FOCUSABLE in addition to ATK\\_STATE\\_FOCUSED  \n;  expected true got false",
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false",
+            "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false",
             "WK01": "assert\\_true: \"property states contains STATE\\_FOCUSED\" failed   \n**Actual value:** None  \nERROR: Object not found  \n; \"property states contains STATE\\_FOCUSABLE\" failed   \n**Actual value:** None  \nERROR: Object not found  \n; \"event type is object:state-changed:focused\" failed   \n;  expected true got false",
             "WK02": "assert_true: \"property AXFocused is true\" failed   \n**Actual value:** false  \n; \"result AXUIElementIsAttributeSettable(AXFocused) is true\" failed   \n**Actual value:** false  \n; \"event type is AXFocusedUIElementChanged\" failed   \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4
+            "FAIL": 5
           }
         }
       }
@@ -5242,26 +5776,31 @@
     "/wai-aria/searchbox_autocomplete_both-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox autocomplete both": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5269,26 +5808,31 @@
     "/wai-aria/searchbox_autocomplete_inline-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox autocomplete inline": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5296,26 +5840,31 @@
     "/wai-aria/searchbox_autocomplete_list-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox autocomplete list": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5323,26 +5872,31 @@
     "/wai-aria/searchbox_autocomplete_none-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox autocomplete none": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5350,26 +5904,31 @@
     "/wai-aria/searchbox_autocomplete_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox autocomplete unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5377,29 +5936,32 @@
     "/wai-aria/searchbox_multiline_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox multiline false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTextField\" failed   \n**Actual value:** AXTextArea  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -5407,29 +5969,32 @@
     "/wai-aria/searchbox_multiline_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox multiline true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTextField\" failed   \n**Actual value:** AXTextArea  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -5437,29 +6002,32 @@
     "/wai-aria/searchbox_multiline_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox multiline unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTextField\" failed   \n**Actual value:** AXTextArea  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -5467,29 +6035,32 @@
     "/wai-aria/searchbox_placeholder-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox placeholder": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property objectAttributes contains placeholder-text:DD/MM/YYYY\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'placeholder:DD/MM/YYYY', 'margin-top:0px', 'xml-roles:searchbox', 'text-input-type:search', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1303429>: [NEW] expose placeholder object attribute for HTML placeholder  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"property AXPlaceholderValue is DD/MM/YYYY\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTextField\" failed   \n**Actual value:** AXTextArea  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -5498,26 +6069,31 @@
     "/wai-aria/searchbox_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5525,28 +6101,31 @@
     "/wai-aria/searchbox_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property interfaces doesNotContain EditableText\" failed   \n**Actual value:** ['Accessible', 'Action', 'Collection', 'Component', 'EditableText', 'Hypertext', 'Hyperlink', 'Text']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n; \"property states contains STATE\\_READ_ONLY\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_SINGLE\\_LINE', 'STATE\\_VISIBLE']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property interfaces doesNotContain EditableText\" failed   \n**Actual value:** ['Accessible', 'Action', 'Collection', 'Component', 'EditableText', 'Hypertext', 'Hyperlink', 'Text']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n; \"property states contains STATE\\_READ_ONLY\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_SINGLE\\_LINE', 'STATE\\_VISIBLE']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"result AXUIElementIsAttributeSettable(AXValue) is false\" failed   \n**Actual value:** true  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
+            "FAIL": 2,
             "PASS": 3
           }
         }
@@ -5555,26 +6134,31 @@
     "/wai-aria/searchbox_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n; \"property AXRoleDescription is search text field\" failed   \n**Actual value:** text field  \n; \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5582,26 +6166,31 @@
     "/wai-aria/searchbox_required_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox required false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5609,26 +6198,31 @@
     "/wai-aria/searchbox_required_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox required true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5636,26 +6230,31 @@
     "/wai-aria/searchbox_required_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "searchbox required unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is AXSearchField\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5663,29 +6262,32 @@
     "/wai-aria/separator_focusable_all_values_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "separator focusable all values unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property interfaces contains Value\" failed   \n**Actual value:** ['Accessible', 'Collection', 'Component', 'Hyperlink']  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_minimum_value() is 0\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_current_value() is 50\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_maximum_value() is 100\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n;  expected true got false",
-            "GC02": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n; \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:** 0.0  \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -5694,29 +6296,32 @@
     "/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "separator focusable only valuenow unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property interfaces contains Value\" failed   \n**Actual value:** ['Accessible', 'Collection', 'Component', 'Hyperlink']  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_minimum_value() is 0\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_current_value() is 50\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_maximum_value() is 100\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n;  expected true got false",
-            "GC02": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n; \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -5725,29 +6330,32 @@
     "/wai-aria/separator_focusable_valuetext-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "separator focusable valuetext": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property objectAttributes contains valuetext:Bonaire\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:separator', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"property interfaces contains Value\" failed   \n**Actual value:** ['Accessible', 'Collection', 'Component', 'Hyperlink']  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_minimum_value() is 0\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_current_value() is 50\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n; \"result atk_value_get_maximum_value() is 100\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1355954>: [NEW] Focusable separators should implement the accessible value interface in IA2 and ATK  \n;  expected true got false",
-            "GC02": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n; \"property AXValueDescription is Bonaire\" failed   \n**Actual value:**   \n;  expected true got false"
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n; \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n; \"property AXValueDescription is Bonaire\" failed   \n**Actual value:** None  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:** 0.0  \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -5756,26 +6364,31 @@
     "/wai-aria/separator_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "separator orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n; \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5783,26 +6396,31 @@
     "/wai-aria/separator_unfocusable_all_values_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "separator unfocusable all values unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5810,26 +6428,31 @@
     "/wai-aria/separator_unfocusable_valuetext-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "separator unfocusable valuetext": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5837,29 +6460,32 @@
     "/wai-aria/slider_all_values_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "slider all values unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_value_get_minimum_value() is 0\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1357071>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles  \n; \"result atk_value_get_current_value() is 50\" failed   \n**Actual value:** 0.0  \n<https://bugzil.la/1357071>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles  \n; \"result atk_value_get_maximum_value() is 100\" failed   \n**Actual value:** 0.0  \n<https://bugzil.la/1357071>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 50\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXValue is 50\" failed   \n**Actual value:** 0.0  \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -5868,29 +6494,32 @@
     "/wai-aria/slider_only_valuenow_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "slider only valuenow unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_value_get_current_value() is 20\" failed   \n**Actual value:** 0.0  \n<https://bugzil.la/1357071>: [NEW] Implement support for implicit values for aria-value* attributes for scrollbar and slider roles  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 20\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 40\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXValue is 20\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -5899,26 +6528,31 @@
     "/wai-aria/slider_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "slider orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5926,26 +6560,31 @@
     "/wai-aria/slider_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "slider readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -5953,19 +6592,21 @@
     "/wai-aria/slider_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "slider readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -5975,7 +6616,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -5983,26 +6624,31 @@
     "/wai-aria/slider_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "slider readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6010,29 +6656,32 @@
     "/wai-aria/spinbutton_all_values_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "spinbutton all values unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_value_get_minimum_value() isLTE -9007199254740992\" failed   \n**Actual value:** None  \nERROR: atspi\\_error: Get failed (1)  \n<https://bugzil.la/1357097>: [NEW] Implement support for implicit values for aria-value* attributes for spinbutton role  \n; \"result atk_value_get_maximum_value() isGTE 9007199254740992\" failed   \n**Actual value:** 0.0  \n<https://bugzil.la/1357097>: [NEW] Implement support for implicit values for aria-value* attributes for spinbutton role  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXMinValue isLTE -9007199254740992\" failed   \n**Actual value:** None  \n; \"property AXValue is 0\" failed   \n**Actual value:**   \n; \"property AXMaxValue isGTE 9007199254740992\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXMinValue isLTE -9007199254740992\" failed   \n**Actual value:** 0.0  \n; \"property AXMaxValue isGTE 9007199254740992\" failed   \n**Actual value:** 0.0  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -6041,26 +6690,31 @@
     "/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "spinbutton only aria-valuenow unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXMinValue is 0\" failed   \n**Actual value:** None  \n; \"property AXValue is 0\" failed   \n**Actual value:**   \n; \"property AXMaxValue is 100\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6068,26 +6722,31 @@
     "/wai-aria/spinbutton_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "spinbutton readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6095,19 +6754,21 @@
     "/wai-aria/spinbutton_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "spinbutton readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -6117,7 +6778,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -6125,26 +6786,31 @@
     "/wai-aria/spinbutton_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "spinbutton readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6152,26 +6818,31 @@
     "/wai-aria/switch_checked_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "switch checked false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXValue is 0\" failed   \n**Actual value:**   \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6179,28 +6850,31 @@
     "/wai-aria/switch_checked_mixed-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "switch checked mixed": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property states doesNotContain STATE\\_CHECKED\" failed   \n**Actual value:** ['STATE\\_CHECKED', 'STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_CHECKABLE']  \n<https://bugzil.la/1358447>: [NEW] Elements with aria-checked=\"mixed\" and role=\"switch\" should not expose ATK\\_STATE\\_CHECKED  \n;  expected true got false"
+            "FF01": "assert\\_true: \"property states doesNotContain STATE\\_CHECKED\" failed   \n**Actual value:** ['STATE\\_CHECKED', 'STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_CHECKABLE']  \n<https://bugzil.la/1358447>: [NEW] Elements which do not support aria-checked=\"mixed\" should not expose \"checked\" accessibility state  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXValue is 0\" failed   \n**Actual value:**   \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 1,
+            "FAIL": 2,
             "PASS": 3
           }
         }
@@ -6209,26 +6883,31 @@
     "/wai-aria/switch_checked_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "switch checked true": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXValue is 1\" failed   \n**Actual value:**   \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6236,26 +6915,31 @@
     "/wai-aria/switch_checked_undefined-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "switch checked undefined": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXValue is 0\" failed   \n**Actual value:**   \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6263,26 +6947,32 @@
     "/wai-aria/switch_checked_value_changes-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "switch checked value changes": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
-            "GC02": "PASS",
+            "FF02": "FAIL",
+            "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXRoleDescription is switch\" failed   \n**Actual value:**   \n; \"property AXValue is 1\" failed   \n;  expected true got false",
+            "GC02": "assert_true: \"property AXValue is 1\" failed   \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 3,
+            "FAIL": 2
           }
         }
       }
@@ -6290,29 +6980,32 @@
     "/wai-aria/switch_readonly_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "switch readonly false": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -6320,19 +7013,21 @@
     "/wai-aria/switch_readonly_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "switch readonly true": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
@@ -6342,7 +7037,7 @@
           },
           "totals": {
             "FAIL": 1,
-            "PASS": 3
+            "PASS": 4
           }
         }
       }
@@ -6350,29 +7045,32 @@
     "/wai-aria/switch_readonly_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "switch readonly unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false",
             "GC02": "assert_true: \"result AXUIElementIsAttributeSettable(AXValue) is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -6380,29 +7078,32 @@
     "/wai-aria/tab_posinset_and_setsize-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "tab posinset and setsize": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"property AXARIAPosInSet is 3\" failed   \n**Actual value:** None  \n; \"property AXARIASetSize is 7\" failed   \n**Actual value:** None  \n; \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAPosInSet is 3\" failed   \n**Actual value:** 0  \n; \"property AXARIASetSize is 7\" failed   \n**Actual value:** 0  \n; \"property AXSelected is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
             "PASS": 3,
-            "FAIL": 1
+            "FAIL": 2
           }
         }
       }
@@ -6410,30 +7111,33 @@
     "/wai-aria/table_colcount_-1-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "table colcount -1": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_columns() is -1\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnCount is -1\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAColumnCount is -1\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_columns() is -1\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -6442,30 +7146,33 @@
     "/wai-aria/table_colcount_8-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "table colcount 8": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_columns() is 8\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_columns() is 8\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -6474,30 +7181,33 @@
     "/wai-aria/table_rowcount_-1-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "table rowcount -1": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_rows() is -1\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
-            "GC02": "assert_true: \"property AXARIARowCount is -1\" failed   \n**Actual value:** None  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIARowCount contains -1\" failed   \n**Actual value:** None  \n;  expected true got false",
+            "GC02": "assert_true: \"property AXARIARowCount contains -1\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_rows() is -1\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -6506,30 +7216,33 @@
     "/wai-aria/table_rowcount_3-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "table rowcount 3": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_rows() is 3\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIARowCount is 3\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXARIARowCount is 3\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_rows() is 3\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 4,
             "PASS": 1
           }
         }
@@ -6538,26 +7251,31 @@
     "/wai-aria/tablist_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "tablist orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6565,26 +7283,31 @@
     "/wai-aria/tablist_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "tablist orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6592,26 +7315,31 @@
     "/wai-aria/tablist_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "tablist orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6619,30 +7347,28 @@
     "/wai-aria/term_role-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "term role": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "PASS",
-            "WK01": "FAIL",
+            "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {
-            "FF01": "assert\\_true: \"property role is ROLE_DESCRIPTION_TERM\" failed   \n**Actual value:** ROLE\\_SECTION  \n<https://bugzil.la/1358417>: [NEW] ARIA term role should be exposed with ATK\\_ROLE\\_DESCRIPTION\\_TERM  \n;  expected true got false",
-            "WK01": "assert\\_true: \"property role is ROLE_DESCRIPTION_TERM\" failed   \n**Actual value:** ROLE\\_UNKNOWN  \nhttps://bugzilla.gnome.org/show\\_bug.cgi?id=782041: Bug 782041 â€“ AT-SPI2 is missing roles that are present in ATK  \n;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
-            "PASS": 2
+            "PASS": 5
           }
         }
       }
@@ -6650,29 +7376,32 @@
     "/wai-aria/textbox_placeholder-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "textbox placeholder": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"property objectAttributes contains placeholder-text:DD/MM/YYYY\" failed   \n**Actual value:** ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'placeholder:DD/MM/YYYY', 'margin-top:0px', 'xml-roles:textbox', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px']  \n<https://bugzil.la/1303429>: [NEW] expose placeholder object attribute for HTML placeholder  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXPlaceholderValue is DD/MM/YYYY\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRole is AXTextField\" failed   \n**Actual value:** AXTextArea  \n; \"property AXRoleDescription is text field\" failed   \n**Actual value:** text entry area  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -6681,26 +7410,31 @@
     "/wai-aria/toolbar_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "toolbar orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6708,26 +7442,31 @@
     "/wai-aria/toolbar_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "toolbar orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6735,26 +7474,31 @@
     "/wai-aria/toolbar_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "toolbar orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6762,26 +7506,31 @@
     "/wai-aria/tree_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "tree orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6789,26 +7538,31 @@
     "/wai-aria/tree_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "tree orientation unspecified": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6816,26 +7570,31 @@
     "/wai-aria/tree_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "tree orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6843,29 +7602,32 @@
     "/wai-aria/treegrid_colcount_8-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treegrid colcount 8": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_columns() is 8\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIAColumnCount is 8\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_columns() is 8\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -6874,26 +7636,31 @@
     "/wai-aria/treegrid_orientation_horizontal-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treegrid orientation horizontal": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXHorizontalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6901,29 +7668,28 @@
     "/wai-aria/treegrid_orientation_unspecified-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treegrid orientation unspecified": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "PASS",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {
-            "FF01": "assert\\_true: \"property states doesNotContain STATE\\_VERTICAL\" failed   \n**Actual value:** ['STATE\\_EDITABLE', 'STATE\\_ENABLED', 'STATE\\_FOCUSABLE', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VERTICAL', 'STATE\\_VISIBLE']  \n<https://bugzil.la/1357042>: [NEW] Implement or update support for exposure of aria-orientation via ATK StateSet  \n;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 1,
-            "PASS": 3
+            "PASS": 5
           }
         }
       }
@@ -6931,26 +7697,31 @@
     "/wai-aria/treegrid_orientation_vertical-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treegrid orientation vertical": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "PASS",
             "WK02": "PASS"
           },
-          "UAmessage": {},
+          "UAmessage": {
+            "FF02": "assert_true: \"property AXOrientation is AXVerticalOrientation\" failed   \n**Actual value:** None  \n;  expected true got false"
+          },
           "totals": {
-            "PASS": 4
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }
@@ -6958,29 +7729,32 @@
     "/wai-aria/treegrid_rowcount_3-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treegrid rowcount 3": {
           "stNum": 0,
           "byUA": {
             "FF01": "FAIL",
+            "FF02": "FAIL",
             "GC02": "PASS",
             "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
             "FF01": "assert\\_true: \"result atk_table_get_n_rows() is 3\" failed   \n**Actual value:** 1  \n<https://bugzil.la/1356997>: [NEW] atk\\_table\\_get\\_n\\_{columns,rows} should report the values of aria-{col,row}count  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXARIARowCount is 3\" failed   \n**Actual value:** None  \n;  expected true got false",
             "WK01": "assert\\_true: \"result atk_table_get_n_rows() is 3\" failed   \n**Actual value:** 1  \n<https://webkit.org/b/171172>: [NEW] [ATK] atk\\_table\\_get\\_n\\_rows() and atk\\_table\\_get\\_n\\_columns() should return values of aria-rowcount and aria-colcount, if present  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 3,
             "PASS": 2
           }
         }
@@ -6989,30 +7763,32 @@
     "/wai-aria/treeitem_selected_false-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treeitem selected false": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property role is ROLE_TREE_ITEM\" failed   \n**Actual value:** ROLE\\_LIST\\_ITEM  \n<https://bugzil.la/1355423>: [NEW] ARIA treeitem role should be mapped as ATK\\_ROLE\\_TREE\\_ITEM; not ATK\\_ROLE\\_LIST\\_ITEM  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRoleDescription is outline row\" failed   \n**Actual value:** row  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
-            "PASS": 2
+            "PASS": 3,
+            "FAIL": 2
           }
         }
       }
@@ -7020,30 +7796,32 @@
     "/wai-aria/treeitem_selected_true-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treeitem selected true": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property role is ROLE_TREE_ITEM\" failed   \n**Actual value:** ROLE\\_LIST\\_ITEM  \n<https://bugzil.la/1355423>: [NEW] ARIA treeitem role should be mapped as ATK\\_ROLE\\_TREE\\_ITEM; not ATK\\_ROLE\\_LIST\\_ITEM  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXSelected is true\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRoleDescription is outline row\" failed   \n**Actual value:** row  \n; \"property AXSelected is true\" failed   \n**Actual value:** false  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
-            "PASS": 2
+            "PASS": 3,
+            "FAIL": 2
           }
         }
       }
@@ -7051,30 +7829,32 @@
     "/wai-aria/treeitem_selected_undefined-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treeitem selected undefined": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "PASS",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert\\_true: \"property role is ROLE_TREE_ITEM\" failed   \n**Actual value:** ROLE\\_LIST\\_ITEM  \n<https://bugzil.la/1355423>: [NEW] ARIA treeitem role should be mapped as ATK\\_ROLE\\_TREE\\_ITEM; not ATK\\_ROLE\\_LIST\\_ITEM  \n;  expected true got false",
+            "FF02": "assert_true: \"property AXSelected is false\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC02": "assert_true: \"property AXRoleDescription is outline row\" failed   \n**Actual value:** row  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 2,
-            "PASS": 2
+            "PASS": 3,
+            "FAIL": 2
           }
         }
       }
@@ -7082,49 +7862,54 @@
     "/wai-aria/treeitem_selected_value_changes-manual.html": {
       "byUA": {
         "FF01": "OK",
+        "FF02": "OK",
         "GC02": "OK",
         "WK01": "OK",
         "WK02": "OK"
       },
       "UAmessage": {},
       "totals": {
-        "OK": 4
+        "OK": 5
       },
       "subtests": {
         "treeitem selected value changes": {
           "stNum": 0,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false",
             "GC02": "assert_true: \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false",
             "WK01": "assert\\_true: \"event type is object:state-changed:selected\" failed <https://webkit.org/b/171185>  \n;  expected true got false",
             "WK02": "assert_true: \"event type is AXSelectedChildrenChanged\" failed   \n;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         },
         "treeitem selected value changes 1": {
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
+            "FF02": "FAIL",
             "GC02": "FAIL",
             "WK01": "FAIL",
             "WK02": "FAIL"
           },
           "UAmessage": {
+            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
             "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
             "WK01": "assert\\_true: \"event type is object:selection-changed\" failed <https://webkit.org/b/171185>  \n;  expected true got false",
             "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 3
+            "FAIL": 4
           }
         },
         "treeitem selected value changes 2": {

--- a/wai-aria/less-than-2.html
+++ b/wai-aria/less-than-2.html
@@ -27,11 +27,11 @@
 <li><a href='#test-file-10'>/wai-aria/columnheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
 <li><a href='#test-file-11'>/wai-aria/columnheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
 <li><a href='#test-file-12'>/wai-aria/combobox_haspopup_dialog-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-13'>/wai-aria/combobox_haspopup_grid-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-14'>/wai-aria/combobox_haspopup_listbox-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-15'>/wai-aria/combobox_haspopup_menu-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-16'>/wai-aria/combobox_haspopup_tree-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-17'>/wai-aria/combobox_haspopup_true-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-13'>/wai-aria/combobox_haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-14'>/wai-aria/combobox_haspopup_grid-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-15'>/wai-aria/combobox_haspopup_listbox-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-16'>/wai-aria/combobox_haspopup_menu-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<li><a href='#test-file-17'>/wai-aria/combobox_haspopup_tree-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
 <li><a href='#test-file-18'>/wai-aria/combobox_haspopup_unspecified-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
 <li><a href='#test-file-19'>/wai-aria/dialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
 <li><a href='#test-file-20'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></li>
@@ -54,16 +54,24 @@
 <li><a href='#test-file-37'>/wai-aria/treeitem_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/wai-aria/alertdialog_modal_true-manual.html' target='_blank'>/wai-aria/alertdialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-1-1' class='subtest'><td>alertdialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>FF02</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/wai-aria/alertdialog_modal_true-manual.html' target='_blank'>/wai-aria/alertdialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-1-1' class='subtest'><td>alertdialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property accessible is false" failed <br />
+<strong>Actual value:</strong> true <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant-manual.html' target='_blank'>/wai-aria/application_activedescendant-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-2-0' class='subtest'><td>application activedescendant</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant-manual.html' target='_blank'>/wai-aria/application_activedescendant-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-2-0' class='subtest'><td>application activedescendant</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is web application" failed <br />
+<strong>Actual value:</strong> group <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
 <strong>Actual value:</strong> AXLandmarkApplication <br />
 ; "property AXRoleDescription is web application" failed <br />
 <strong>Actual value:</strong> application <br />
@@ -75,12 +83,13 @@
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-2-1' class='subtest'><td>application activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr id='subtest-2-1' class='subtest'><td>application activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
@@ -96,9 +105,17 @@
 <strong>Actual value:</strong> false <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-3-0' class='subtest'><td>application activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/wai-aria/application_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/application_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-3-0' class='subtest'><td>application activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is web application" failed <br />
+<strong>Actual value:</strong> group <br />
+; "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXSelectedChildrenChanged" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXSubrole is AXWebApplication" failed <br />
 <strong>Actual value:</strong> AXLandmarkApplication <br />
 ; "property AXRoleDescription is web application" failed <br />
 <strong>Actual value:</strong> application <br />
@@ -112,16 +129,18 @@
 ; "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-3-1' class='subtest'><td>application activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr id='subtest-3-1' class='subtest'><td>application activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE'] <br />
@@ -136,64 +155,54 @@
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-13-0' class='subtest'><td>aria-details pointing to details element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_details_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_details_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-13-0' class='subtest'><td>aria-details pointing to details element</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is [details]" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: Object not found <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165842">https://webkit.org/b/165842</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-13-1' class='subtest'><td>aria-details pointing to details element 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
+<tr id='subtest-13-1' class='subtest'><td>aria-details pointing to details element 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-14-0' class='subtest'><td>aria-details pointing to div element</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/wai-aria/aria-details_pointing_to_div_element-manual.html' target='_blank'>/wai-aria/aria-details_pointing_to_div_element-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-14-0' class='subtest'><td>aria-details pointing to div element</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is details" failed <br />
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS is [details]" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: Object not found <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165842">https://webkit.org/b/165842</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-14-1' class='subtest'><td>aria-details pointing to div element 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
+<tr id='subtest-14-1' class='subtest'><td>aria-details pointing to div element 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 – Add details and details-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_DETAILS_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add details and details-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_emptystring-manual.html' target='_blank'>/wai-aria/button_haspopup_emptystring-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-19-0' class='subtest'><td>button haspopup emptystring</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:false" failed <br />
+<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_emptystring-manual.html' target='_blank'>/wai-aria/button_haspopup_emptystring-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-19-0' class='subtest'><td>button haspopup emptystring</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:false" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXPress, <br />
@@ -225,11 +234,19 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_foo-manual.html' target='_blank'>/wai-aria/button_haspopup_foo-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-21-0' class='subtest'><td>button haspopup foo</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:false" failed <br />
+<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/wai-aria/button_haspopup_foo-manual.html' target='_blank'>/wai-aria/button_haspopup_foo-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-21-0' class='subtest'><td>button haspopup foo</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:false" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:button', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
+; "property states doesNotContain STATE_HAS_POPUP" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_HAS_POPUP'] <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
 <strong>Actual value:</strong> ( <br />
@@ -262,11 +279,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/wai-aria/cell-manual.html' target='_blank'>/wai-aria/cell-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-31-0' class='subtest'><td>cell</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
+<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/wai-aria/cell-manual.html' target='_blank'>/wai-aria/cell-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-31-0' class='subtest'><td>cell</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -276,10 +296,13 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-31-1' class='subtest'><td>cell 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr id='subtest-31-1' class='subtest'><td>cell 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -289,11 +312,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/wai-aria/cell_colindex_4-manual.html' target='_blank'>/wai-aria/cell_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-41-0' class='subtest'><td>cell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/wai-aria/cell_colindex_4-manual.html' target='_blank'>/wai-aria/cell_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-41-0' class='subtest'><td>cell colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -303,11 +329,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/wai-aria/cell_rowindex_4-manual.html' target='_blank'>/wai-aria/cell_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-42-0' class='subtest'><td>cell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/wai-aria/cell_rowindex_4-manual.html' target='_blank'>/wai-aria/cell_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-42-0' class='subtest'><td>cell rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -317,11 +346,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_colindex_4-manual.html' target='_blank'>/wai-aria/columnheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-54-0' class='subtest'><td>columnheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_colindex_4-manual.html' target='_blank'>/wai-aria/columnheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-54-0' class='subtest'><td>columnheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -331,11 +363,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_rowindex_4-manual.html' target='_blank'>/wai-aria/columnheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-55-0' class='subtest'><td>columnheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/wai-aria/columnheader_rowindex_4-manual.html' target='_blank'>/wai-aria/columnheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-55-0' class='subtest'><td>columnheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -345,15 +380,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_dialog-manual.html' target='_blank'>/wai-aria/combobox_haspopup_dialog-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-59-0' class='subtest'><td>combobox haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:dialog" failed <br />
+<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_dialog-manual.html' target='_blank'>/wai-aria/combobox_haspopup_dialog-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-59-0' class='subtest'><td>combobox haspopup dialog</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:dialog" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -368,15 +411,55 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-61'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_grid-manual.html' target='_blank'>/wai-aria/combobox_haspopup_grid-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-61-0' class='subtest'><td>combobox haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:grid" failed <br />
+<tr class='test' id='test-file-60'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_false-manual.html' target='_blank'>/wai-aria/combobox_haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-60-0' class='subtest'><td>combobox haspopup false</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states doesNotContain STATE_HAS_POPUP" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_HAS_POPUP'] <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions doesNotContain AXPress" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property actions doesNotContain AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXShowMenu, <br />
+    AXScrollToVisible <br />
+) <br />
+<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
+;  expected true got false</td></tr>
+</table></td></tr>
+<tr class='test' id='test-file-61'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_grid-manual.html' target='_blank'>/wai-aria/combobox_haspopup_grid-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-61-0' class='subtest'><td>combobox haspopup grid</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:grid" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -391,15 +474,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_listbox-manual.html' target='_blank'>/wai-aria/combobox_haspopup_listbox-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-62-0' class='subtest'><td>combobox haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:listbox" failed <br />
+<tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_listbox-manual.html' target='_blank'>/wai-aria/combobox_haspopup_listbox-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-62-0' class='subtest'><td>combobox haspopup listbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:listbox" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -414,15 +505,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-63'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_menu-manual.html' target='_blank'>/wai-aria/combobox_haspopup_menu-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-63-0' class='subtest'><td>combobox haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:menu" failed <br />
+<tr class='test' id='test-file-63'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_menu-manual.html' target='_blank'>/wai-aria/combobox_haspopup_menu-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-63-0' class='subtest'><td>combobox haspopup menu</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:menu" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -437,15 +536,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-64'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_tree-manual.html' target='_blank'>/wai-aria/combobox_haspopup_tree-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-64-0' class='subtest'><td>combobox haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:tree" failed <br />
+<tr class='test' id='test-file-64'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_tree-manual.html' target='_blank'>/wai-aria/combobox_haspopup_tree-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-64-0' class='subtest'><td>combobox haspopup tree</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:tree" failed <br />
 <strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -460,35 +567,23 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-65'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_true-manual.html' target='_blank'>/wai-aria/combobox_haspopup_true-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-65-0' class='subtest'><td>combobox haspopup true</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property actions contains AXPress" failed <br />
-<strong>Actual value:</strong> ( <br />
-    AXShowMenu, <br />
-    AXScrollToVisible <br />
-) <br />
-<a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-66'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/combobox_haspopup_unspecified-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-66-0' class='subtest'><td>combobox haspopup unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_HAS_POPUP" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_EXPANDABLE', 'STATE_EXPANDED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-<a href="https://bugzil.la/1355447">https://bugzil.la/1355447</a>: [NEW] Elements having aria-haspopup with a value other than false should expose ATK_STATE_HAS_POPUP <br />
-; "property objectAttributes contains haspopup:listbox" failed <br />
-<strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'haspopup:true', 'text-align:start', 'margin-left:0px'] <br />
+<tr class='test' id='test-file-66'><td><a href='http://www.w3c-test.org/wai-aria/combobox_haspopup_unspecified-manual.html' target='_blank'>/wai-aria/combobox_haspopup_unspecified-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-66-0' class='subtest'><td>combobox haspopup unspecified</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property objectAttributes contains haspopup:listbox" failed <br />
+<strong>Actual value:</strong> ['formatting:block', 'explicit-name:true', 'display:block', 'margin-right:0px', 'margin-bottom:0px', 'margin-top:0px', 'xml-roles:combobox', 'tag:div', 'id:test', 'text-indent:0px', 'text-align:start', 'margin-left:0px'] <br />
 <a href="https://bugzil.la/1355449">https://bugzil.la/1355449</a>: [NEW] Elements having aria-haspopup with a value other than false should expose that value as an object attribute <br />
 ;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRole is AXComboBox" failed <br />
+<strong>Actual value:</strong> AXPopUpButton <br />
+; "property AXRoleDescription is combo box" failed <br />
+<strong>Actual value:</strong> pop up button <br />
+; "property AXExpanded is true" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property actions contains AXShowMenu" failed <br />
+<strong>Actual value:</strong> ( <br />
+    AXPress <br />
+) <br />
+;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property actions contains AXPress" failed <br />
 <strong>Actual value:</strong> ( <br />
     AXShowMenu, <br />
@@ -503,67 +598,57 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781591: Bug 781591 â€“ Add detai
 <a href="https://github.com/w3c/aria/issues/570">https://github.com/w3c/aria/issues/570</a>: [OPEN] Core-AAM: AXPress and AXShowMenu on aria-haspopup is potentially misleading/confusing <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_true-manual.html' target='_blank'>/wai-aria/dialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-74-1' class='subtest'><td>dialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
+<tr class='test' id='test-file-74'><td><a href='http://www.w3c-test.org/wai-aria/dialog_modal_true-manual.html' target='_blank'>/wai-aria/dialog_modal_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-74-1' class='subtest'><td>dialog modal true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property accessible is false" failed <br />
+<strong>Actual value:</strong> true <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-77-0' class='subtest'><td>errormessage object in invalid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
+<tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_invalid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_invalid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-77-0' class='subtest'><td>errormessage object in invalid state</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE exists false" failed <br />
+<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is [error]" failed <br />
 <strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-77-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
+<tr id='subtest-77-1' class='subtest'><td>errormessage object in invalid state 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_FOR is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_FOR exists false" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-78-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
+<tr class='test' id='test-file-78'><td><a href='http://www.w3c-test.org/wai-aria/errormessage_object_in_valid_state-manual.html' target='_blank'>/wai-aria/errormessage_object_in_valid_state-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-78-0' class='subtest'><td>errormessage object in valid state</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property relations doesNotContain RELATION_ERROR_MESSAGE" failed <br />
+<strong>Actual value:</strong> ['RELATION_LABELLED_BY', 'RELATION_ERROR_MESSAGE'] <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property TBD is TBD" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property TBD is TBD" failed <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_MESSAGE is error" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "property TBD is TBD" failed <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-78-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 – Add error-message and error-for relation types <br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: "relation RELATION_ERROR_FOR is test" failed <br />
-<strong>Actual value:</strong> [] <br />
-https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error-message and error-for relation types <br />
+<tr id='subtest-78-1' class='subtest'><td>errormessage object in valid state 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property relations doesNotContain RELATION_ERROR_FOR" failed <br />
+<strong>Actual value:</strong> ['RELATION_ERROR_FOR'] <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/wai-aria/grid_colcount_8-manual.html' target='_blank'>/wai-aria/grid_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-86-0' class='subtest'><td>grid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
+<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/wai-aria/grid_colcount_8-manual.html' target='_blank'>/wai-aria/grid_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-86-0' class='subtest'><td>grid colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
@@ -573,11 +658,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-93'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowcount_3-manual.html' target='_blank'>/wai-aria/grid_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-93-0' class='subtest'><td>grid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
+<tr class='test' id='test-file-93'><td><a href='http://www.w3c-test.org/wai-aria/grid_rowcount_3-manual.html' target='_blank'>/wai-aria/grid_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-93-0' class='subtest'><td>grid rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowCount is 3" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXRole is AXTable" failed <br />
 <strong>Actual value:</strong> AXGrid <br />
@@ -587,9 +675,14 @@ https://bugzilla.gnome.org/show_bug.cgi?id=781587: Bug 781587 â€“ Add error
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-107'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_multiple_shortcuts-manual.html' target='_blank'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-107-0' class='subtest'><td>keyshortcuts multiple shortcuts</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
+<tr class='test' id='test-file-107'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_multiple_shortcuts-manual.html' target='_blank'>/wai-aria/keyshortcuts_multiple_shortcuts-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-107-0' class='subtest'><td>keyshortcuts multiple shortcuts</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
+<strong>Actual value:</strong> None <br />
+ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
+ERROR: 'NoneType' object is not callable <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
 ERROR: 'NoneType' object is not callable <br />
@@ -605,9 +698,14 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/159215">https://webkit.org/b/159215</a>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-108'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_one_shortcut-manual.html' target='_blank'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-108-0' class='subtest'><td>keyshortcuts one shortcut</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
+<tr class='test' id='test-file-108'><td><a href='http://www.w3c-test.org/wai-aria/keyshortcuts_one_shortcut-manual.html' target='_blank'>/wai-aria/keyshortcuts_one_shortcut-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-108-0' class='subtest'><td>keyshortcuts one shortcut</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
+<strong>Actual value:</strong> None <br />
+ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
+ERROR: 'NoneType' object is not callable <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result The element with role="button" and id="test", does not expose aria-keyshortcuts is true" failed <br />
 <strong>Actual value:</strong> None <br />
 ERROR: The element with role="button" and id="test", does not expose aria-keyshortcuts is not supported <br />
 ERROR: 'NoneType' object is not callable <br />
@@ -623,30 +721,36 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/159215">https://webkit.org/b/159215</a>: [NEW] AX: ARIA 1.1 @aria-keyshortcuts <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-139'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_value_changes-manual.html' target='_blank'>/wai-aria/option_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-139-0' class='subtest'><td>option selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
+<tr class='test' id='test-file-139'><td><a href='http://www.w3c-test.org/wai-aria/option_selected_value_changes-manual.html' target='_blank'>/wai-aria/option_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-139-0' class='subtest'><td>option selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-139-1' class='subtest'><td>option selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
+<tr id='subtest-139-1' class='subtest'><td>option selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:selection-changed" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-139-2' class='subtest'><td>option selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
+<tr id='subtest-139-2' class='subtest'><td>option selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171186">https://webkit.org/b/171186</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-148'><td><a href='http://www.w3c-test.org/wai-aria/row_colindex_4-manual.html' target='_blank'>/wai-aria/row_colindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-148-1' class='subtest'><td>row colindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr class='test' id='test-file-148'><td><a href='http://www.w3c-test.org/wai-aria/row_colindex_4-manual.html' target='_blank'>/wai-aria/row_colindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-148-1' class='subtest'><td>row colindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -656,11 +760,14 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-149'><td><a href='http://www.w3c-test.org/wai-aria/row_rowindex_4-manual.html' target='_blank'>/wai-aria/row_rowindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-149-1' class='subtest'><td>row rowindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr class='test' id='test-file-149'><td><a href='http://www.w3c-test.org/wai-aria/row_rowindex_4-manual.html' target='_blank'>/wai-aria/row_rowindex_4-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-149-1' class='subtest'><td>row rowindex 4 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -670,11 +777,14 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-152'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_colindex_4-manual.html' target='_blank'>/wai-aria/rowheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-152-0' class='subtest'><td>rowheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
+<tr class='test' id='test-file-152'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_colindex_4-manual.html' target='_blank'>/wai-aria/rowheader_colindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-152-0' class='subtest'><td>rowheader colindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains column=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -684,11 +794,14 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-153'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_rowindex_4-manual.html' target='_blank'>/wai-aria/rowheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-153-0' class='subtest'><td>rowheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
+<tr class='test' id='test-file-153'><td><a href='http://www.w3c-test.org/wai-aria/rowheader_rowindex_4-manual.html' target='_blank'>/wai-aria/rowheader_rowindex_4-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-153-0' class='subtest'><td>rowheader rowindex 4</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>cell<em>get</em>position() contains row=3" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://bugzil.la/1357188">https://bugzil.la/1357188</a>: [NEW] atk_table_cell_get_position() should report the values of aria-rowindex and aria-colindex <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowIndex is 4" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -698,17 +811,19 @@ ERROR: 'NoneType' object is not callable <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr class='test' id='test-file-160'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-160-1' class='subtest'><td>searchbox activedescendant 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -725,9 +840,17 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-161-0' class='subtest'><td>searchbox activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result array isNot true" failed <br />
+<tr class='test' id='test-file-161'><td><a href='http://www.w3c-test.org/wai-aria/searchbox_activedescendant_value_changes-manual.html' target='_blank'>/wai-aria/searchbox_activedescendant_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.79% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-161-0' class='subtest'><td>searchbox activedescendant value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXSubrole is AXSearchField" failed <br />
+<strong>Actual value:</strong> None <br />
+; "property AXRoleDescription is search text field" failed <br />
+<strong>Actual value:</strong> text field <br />
+; "event type is AXSelectedChildrenChanged" failed <br />
+<strong>Actual value:</strong> false <br />
+; "result array isNot true" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result array isNot true" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states doesNotContain STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> ['STATE_EDITABLE', 'STATE_ENABLED', 'STATE_FOCUSABLE', 'STATE_FOCUSED', 'STATE_HORIZONTAL', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_SINGLE_LINE', 'STATE_VISIBLE'] <br />
@@ -737,16 +860,18 @@ ERROR: Object not found <br />
 ; "result array isNot true" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
-; "property states contains STATE_FOCUSABLE" failed <br />
-<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
+<tr id='subtest-161-1' class='subtest'><td>searchbox activedescendant value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property states contains STATE_FOCUSABLE" failed <br />
+<strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_FOCUSED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT'] <br />
 <a href="https://bugzil.la/1359045">https://bugzil.la/1359045</a>: [NEW] A container's active descendant should expose ATK_STATE_FOCUSABLE in addition to ATK_STATE_FOCUSED <br />
-; "event type is object:state-changed:focused" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
+<strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "result AXUIElementIsAttributeSettable(AXFocused) is true" failed <br />
 <strong>Actual value:</strong> false <br />
+; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property states contains STATE_FOCUSED" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -763,11 +888,14 @@ ERROR: Object not found <br />
 ; "event type is AXFocusedUIElementChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-203'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_-1-manual.html' target='_blank'>/wai-aria/table_colcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-203-0' class='subtest'><td>table colcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is -1" failed <br />
+<tr class='test' id='test-file-203'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_-1-manual.html' target='_blank'>/wai-aria/table_colcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-203-0' class='subtest'><td>table colcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is -1" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is -1" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnCount is -1" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -777,11 +905,14 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-204'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_8-manual.html' target='_blank'>/wai-aria/table_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-204-0' class='subtest'><td>table colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
+<tr class='test' id='test-file-204'><td><a href='http://www.w3c-test.org/wai-aria/table_colcount_8-manual.html' target='_blank'>/wai-aria/table_colcount_8-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-204-0' class='subtest'><td>table colcount 8</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>columns() is 8" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIAColumnCount is 8" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -791,13 +922,16 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-205'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_-1-manual.html' target='_blank'>/wai-aria/table_rowcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-205-0' class='subtest'><td>table rowcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is -1" failed <br />
+<tr class='test' id='test-file-205'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_-1-manual.html' target='_blank'>/wai-aria/table_rowcount_-1-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-205-0' class='subtest'><td>table rowcount -1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is -1" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowCount is -1" failed <br />
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowCount contains -1" failed <br />
+<strong>Actual value:</strong> None <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowCount contains -1" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is -1" failed <br />
@@ -805,11 +939,14 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-206'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_3-manual.html' target='_blank'>/wai-aria/table_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-206-0' class='subtest'><td>table rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
+<tr class='test' id='test-file-206'><td><a href='http://www.w3c-test.org/wai-aria/table_rowcount_3-manual.html' target='_blank'>/wai-aria/table_rowcount_3-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-206-0' class='subtest'><td>table rowcount 3</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "result atk<em>table</em>get<em>n</em>rows() is 3" failed <br />
 <strong>Actual value:</strong> 1 <br />
 <a href="https://bugzil.la/1356997">https://bugzil.la/1356997</a>: [NEW] atk_table_get_n_{columns,rows} should report the values of aria-{col,row}count <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIARowCount is 3" failed <br />
+<strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXARIARowCount is 3" failed <br />
 <strong>Actual value:</strong> None <br />
@@ -819,23 +956,26 @@ ERROR: Object not found <br />
 <a href="https://webkit.org/b/171172">https://webkit.org/b/171172</a>: [NEW] [ATK] atk_table_get_n_rows() and atk_table_get_n_columns() should return values of aria-rowcount and aria-colcount, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-226'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_value_changes-manual.html' target='_blank'>/wai-aria/treeitem_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-226-0' class='subtest'><td>treeitem selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
+<tr class='test' id='test-file-226'><td><a href='http://www.w3c-test.org/wai-aria/treeitem_selected_value_changes-manual.html' target='_blank'>/wai-aria/treeitem_selected_value_changes-manual.html</a> <small>(3/3, 100.00%, 1.19% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-226-0' class='subtest'><td>treeitem selected value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
+;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXSelectedChildrenChanged" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-226-1' class='subtest'><td>treeitem selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
+<tr id='subtest-226-1' class='subtest'><td>treeitem selected value changes 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
+<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:selection-changed" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-226-2' class='subtest'><td>treeitem selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='5'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
+<tr id='subtest-226-2' class='subtest'><td>treeitem selected value changes 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:selected" failed <a href="https://webkit.org/b/171185">https://webkit.org/b/171185</a> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
 


### PR DESCRIPTION
DPub AAM:
* Updated results for Firefox on Linux (now 100% passing)
* Added results for Firefox on macOS and on Windows (IA2)
* Provide more specific information about Chrome Canary (macOS) failures
* Fix some nits in README.md

ARIA:
* Updated results for Firefox on Linux
* Added results for Firefox on macOS
* Tests re-run and reports regenerated using new "NOTRUN" handling
* Fix some nits in README.md
