### PR TITLE
DPUB-AAM: Update results for Firefox in macOS

### DIFF
--- a/dpub-aam/FF02.json
+++ b/dpub-aam/FF02.json
@@ -17,8 +17,8 @@
       "subtests": [
         {
           "name": "doc-acknowledgments",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -29,8 +29,8 @@
       "subtests": [
         {
           "name": "doc-afterword",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -41,8 +41,8 @@
       "subtests": [
         {
           "name": "doc-appendix",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -82,8 +82,8 @@
       "subtests": [
         {
           "name": "doc-bibliography",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -111,8 +111,8 @@
       "subtests": [
         {
           "name": "doc-chapter",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -135,8 +135,8 @@
       "subtests": [
         {
           "name": "doc-conclusion",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -171,8 +171,8 @@
       "subtests": [
         {
           "name": "doc-credits",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -207,8 +207,8 @@
       "subtests": [
         {
           "name": "doc-endnotes",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -231,8 +231,8 @@
       "subtests": [
         {
           "name": "doc-epilogue",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -243,8 +243,8 @@
       "subtests": [
         {
           "name": "doc-errata",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -267,8 +267,8 @@
       "subtests": [
         {
           "name": "doc-footnote",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is AXApplicationGroup\" failed   \n**Actual value:** None  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -279,8 +279,8 @@
       "subtests": [
         {
           "name": "doc-foreword",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -291,8 +291,8 @@
       "subtests": [
         {
           "name": "doc-glossary",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -332,8 +332,8 @@
       "subtests": [
         {
           "name": "doc-introduction",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -373,8 +373,8 @@
       "subtests": [
         {
           "name": "doc-pagebreak",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXSubrole is <nil>\" failed   \n**Actual value:** AXContentSeparator  \n; \"property AXRoleDescription is splitter\" failed   \n**Actual value:** separator  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -397,8 +397,8 @@
       "subtests": [
         {
           "name": "doc-part",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -409,8 +409,8 @@
       "subtests": [
         {
           "name": "doc-preface",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -421,8 +421,8 @@
       "subtests": [
         {
           "name": "doc-prologue",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is region\" failed   \n**Actual value:** group  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",
@@ -457,8 +457,8 @@
       "subtests": [
         {
           "name": "doc-subtitle",
-          "status": "FAIL",
-          "message": "assert_true: \"property AXRoleDescription is heading\" failed   \n**Actual value:** AXHeading  \n;  expected true got false"
+          "status": "PASS",
+          "message": null
         }
       ],
       "status": "OK",


### PR DESCRIPTION
A number of bug fixes have now landed in Firefox:
* DPub ARIA footnote role should have AXSubrole AXApplicationGroup
* Fix AXRoleDescription for ARIA heading role
* Fix macOS AXRoleDescription for DPub ARIA AXLandmarkRegion
* Fix macOS mapping for ARIA separator role