### PR TITLE
[presentation-api] Update Test Results

### DIFF
--- a/presentation-api/controlling-ua/CA63.json
+++ b/presentation-api/controlling-ua/CA63.json
@@ -1,0 +1,730 @@
+{
+  "results": [
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_error.https.html",
+      "subtests": [
+        {
+          "name": "Call PresentationRequest() constructor without presentation URL. TypeError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with an empty sequence. NotSupportedError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html",
+      "subtests": [
+        {
+          "name": "Creating a PresentationRequest with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html",
+      "subtests": [
+        {
+          "name": "Creating a PresentationRequest with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_sandboxing_error.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Creating a PresentationRequest from a nested context fails when allow-presentation is not set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Creating a PresentationRequest from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_success.https.html",
+      "subtests": [
+        {
+          "name": "Constructing a PresentationRequest",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/defaultRequest.https.html",
+      "subtests": [
+        {
+          "name": "Setting a default presentation request",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/getAvailability.https.html",
+      "subtests": [
+        {
+          "name": "Getting the presentation displays availability information.",
+          "status": "FAIL",
+          "message": "assert_not_equals: If the Promise from a previous call to getAvailability has already been settled, getAvailability returns a new Promise. got disallowed value object \"[object Promise]\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/getAvailability_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Retrieving display availability from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/idlharness.https.html",
+      "subtests": [
+        {
+          "name": "Navigator interface: attribute presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: attribute defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation must be primary interface of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: navigator.presentation must inherit property \"defaultRequest\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation start()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation reconnect(USVString)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation getAvailability()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: attribute onconnectionavailable",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of navigator.presentation.defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation.defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on navigator.presentation.defaultRequest with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of presentation_request",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of presentation_request",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on presentation_request with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of presentation_request_urls",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of presentation_request_urls",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on presentation_request_urls with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: attribute value",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: attribute onchange",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: attribute connection",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute id",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute url",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute state",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation close()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation terminate()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onconnect",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onclose",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onterminate",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute binaryType",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onmessage",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(DOMString)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(Blob)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBuffer)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBufferView)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute reason",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute message",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_notfound_error.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"reconnect\" with an unknown presentation ID fails with a NotFoundError exception",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Reconnecting a presentation from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_error.https.html",
+      "subtests": [
+        {
+          "name": "The presentation could not start, because a user gesture is required.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html",
+      "subtests": [
+        {
+          "name": "Monitoring the list of available presentation displays.",
+          "status": "TIMEOUT"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html",
+      "subtests": [
+        {
+          "name": "Closing a PresentationConnection",
+          "status": "FAIL",
+          "message": "assert_equals: Expected close event, but got connect event instead expected \"close\" but got \"connect\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onconnect-manual.https.html",
+      "subtests": [
+        {
+          "name": "Establishing a presentation connection",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html",
+      "subtests": [
+        {
+          "name": "Receiving a message through PresentationConnection",
+          "status": "TIMEOUT"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html",
+      "subtests": [
+        {
+          "name": "Terminating a presentation in a controlling browsing context",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: \"The presentation is not terminated successfully when the presentation connection in \\\"connecting\\\" state.\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html",
+      "subtests": [
+        {
+          "name": "Sending a message through PresentationConnection",
+          "status": "TIMEOUT"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html",
+      "subtests": [
+        {
+          "name": "Firing a connectionavailable event at a controlling user agent",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/defaultRequest_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "[Optional] Starting a presentation from the browser using a default presentation request.",
+          "status": "FAIL",
+          "message": "assert_unreached: This browser does not support defaultRequest. Reached unreachable code"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Reconnect to presentation success manual test",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: object \"NotFoundError: Route not found.\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when the user denied permission to use the display returns a Promise rejected with a NotAllowedError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.",
+          "status": "FAIL",
+          "message": "assert_throws: function \"function () { throw e }\" threw object \"NotAllowedError: Dialog closed.\" that is not a DOMException NotFoundError: property \"code\" is equal to 0, expected 8"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: starting a presentation from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Checking the chain of events when starting a new presentation",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when there is already an unsettled Promise returns a Promise rejected with an OperationError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/presentation-api/controlling-ua/CD63.json
+++ b/presentation-api/controlling-ua/CD63.json
@@ -1,0 +1,732 @@
+{
+  "results": [
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_error.https.html",
+      "subtests": [
+        {
+          "name": "Call PresentationRequest() constructor without presentation URL. TypeError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with an empty sequence. NotSupportedError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html",
+      "subtests": [
+        {
+          "name": "Creating a PresentationRequest with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html",
+      "subtests": [
+        {
+          "name": "Creating a PresentationRequest with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_sandboxing_error.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Creating a PresentationRequest from a nested context fails when allow-presentation is not set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Creating a PresentationRequest from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_success.https.html",
+      "subtests": [
+        {
+          "name": "Constructing a PresentationRequest",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/defaultRequest.https.html",
+      "subtests": [
+        {
+          "name": "Setting a default presentation request",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/getAvailability.https.html",
+      "subtests": [
+        {
+          "name": "Getting the presentation displays availability information.",
+          "status": "FAIL",
+          "message": "assert_not_equals: If the Promise from a previous call to getAvailability has already been settled, getAvailability returns a new Promise. got disallowed value object \"[object Promise]\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/getAvailability_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Retrieving display availability from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/idlharness.https.html",
+      "subtests": [
+        {
+          "name": "Navigator interface: attribute presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: attribute defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation must be primary interface of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: navigator.presentation must inherit property \"defaultRequest\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation start()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation reconnect(USVString)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation getAvailability()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: attribute onconnectionavailable",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of navigator.presentation.defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation.defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on navigator.presentation.defaultRequest with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of presentation_request",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of presentation_request",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on presentation_request with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of presentation_request_urls",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of presentation_request_urls",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on presentation_request_urls with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: attribute value",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: attribute onchange",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: attribute connection",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute id",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute url",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute state",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation close()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation terminate()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onconnect",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onclose",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onterminate",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute binaryType",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onmessage",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(DOMString)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(Blob)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBuffer)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBufferView)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute reason",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute message",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_notfound_error.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"reconnect\" with an unknown presentation ID fails with a NotFoundError exception",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Reconnecting a presentation from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_error.https.html",
+      "subtests": [
+        {
+          "name": "The presentation could not start, because a user gesture is required.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html",
+      "subtests": [
+        {
+          "name": "Monitoring the list of available presentation displays.",
+          "status": "TIMEOUT"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html",
+      "subtests": [
+        {
+          "name": "Closing a PresentationConnection",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: \"The presentation connection in \\\"connecting\\\" state was not closed successfully.\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onconnect-manual.https.html",
+      "subtests": [
+        {
+          "name": "Establishing a presentation connection",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html",
+      "subtests": [
+        {
+          "name": "Receiving a message through PresentationConnection",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html",
+      "subtests": [
+        {
+          "name": "Terminating a presentation in a controlling browsing context",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: \"The presentation is not terminated successfully when the presentation connection in \\\"connecting\\\" state.\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html",
+      "subtests": [
+        {
+          "name": "Sending a message through PresentationConnection",
+          "status": "FAIL",
+          "message": "assert_equals: Expected connect event, but got close event instead expected \"connect\" but got \"close\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html",
+      "subtests": [
+        {
+          "name": "Firing a connectionavailable event at a controlling user agent",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/defaultRequest_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "[Optional] Starting a presentation from the browser using a default presentation request.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Reconnect to presentation success manual test",
+          "status": "FAIL",
+          "message": "assert_equals: Expected connect event, but got close event instead expected \"connect\" but got \"close\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when the user denied permission to use the display returns a Promise rejected with a NotAllowedError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.",
+          "status": "FAIL",
+          "message": "assert_throws: function \"function () { throw e }\" threw object \"NotAllowedError: Dialog closed.\" that is not a DOMException NotFoundError: property \"code\" is equal to 0, expected 8"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: starting a presentation from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Checking the chain of events when starting a new presentation",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when there is already an unsettled Promise returns a Promise rejected with an OperationError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/presentation-api/controlling-ua/FA57.json
+++ b/presentation-api/controlling-ua/FA57.json
@@ -1,0 +1,732 @@
+{
+  "results": [
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_error.https.html",
+      "subtests": [
+        {
+          "name": "Call PresentationRequest() constructor without presentation URL. TypeError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with an empty sequence. NotSupportedError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html",
+      "subtests": [
+        {
+          "name": "Creating a PresentationRequest with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.",
+          "status": "FAIL",
+          "message": "assert_throws: function \"function createPresentation() {\n        var request = new PresentationRequest('http://example.org/presentation.html');\n    }\" did not throw"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html",
+      "subtests": [
+        {
+          "name": "Creating a PresentationRequest with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.",
+          "status": "FAIL",
+          "message": "assert_throws: function \"function createPresentation() {\n        var request = new PresentationRequest([\n          'presentation.html',\n          'http://example.org/presentation.html'\n        ]);\n    }\" did not throw"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_sandboxing_error.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Creating a PresentationRequest from a nested context fails when allow-presentation is not set",
+          "status": "FAIL",
+          "message": "assert_equals: Presentation sandboxing did not work as expected. expected \"SecurityError\" but got \"success\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Creating a PresentationRequest from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_success.https.html",
+      "subtests": [
+        {
+          "name": "Constructing a PresentationRequest",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/defaultRequest.https.html",
+      "subtests": [
+        {
+          "name": "Setting a default presentation request",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/getAvailability.https.html",
+      "subtests": [
+        {
+          "name": "Getting the presentation displays availability information.",
+          "status": "FAIL",
+          "message": "assert_equals: If the PresentationRequest object has an unsettled Promise, getAvailability returns that Promise. expected object \"[object Promise]\" but got object \"[object Promise]\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/getAvailability_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Retrieving display availability from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/idlharness.https.html",
+      "subtests": [
+        {
+          "name": "Navigator interface: attribute presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: attribute defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation must be primary interface of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: navigator.presentation must inherit property \"defaultRequest\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation start()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation reconnect(USVString)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: operation getAvailability()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: attribute onconnectionavailable",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of navigator.presentation.defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation.defaultRequest",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on navigator.presentation.defaultRequest with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of presentation_request",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of presentation_request",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on presentation_request with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest must be primary interface of presentation_request_urls",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of presentation_request_urls",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"start()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"reconnect(USVString)\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: calling reconnect(USVString) on presentation_request_urls with too few arguments must throw TypeError",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"getAvailability()\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationRequest interface: presentation_request_urls must inherit property \"onconnectionavailable\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: attribute value",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationAvailability interface: attribute onchange",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: attribute connection",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute id",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute url",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute state",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation close()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation terminate()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onconnect",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onclose",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onterminate",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute binaryType",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onmessage",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(DOMString)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(Blob)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBuffer)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBufferView)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute reason",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute message",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_notfound_error.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"reconnect\" with an unknown presentation ID fails with a NotFoundError exception",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_success.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: Reconnecting a presentation from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_error.https.html",
+      "subtests": [
+        {
+          "name": "The presentation could not start, because a user gesture is required.",
+          "status": "FAIL",
+          "message": "assert_unreached: Should have rejected: undefined Reached unreachable code"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html",
+      "subtests": [
+        {
+          "name": "Monitoring the list of available presentation displays.",
+          "status": "TIMEOUT"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html",
+      "subtests": [
+        {
+          "name": "Closing a PresentationConnection",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: object \"OperationError: The operation failed for an operation-specific reason\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onconnect-manual.https.html",
+      "subtests": [
+        {
+          "name": "Establishing a presentation connection",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html",
+      "subtests": [
+        {
+          "name": "Receiving a message through PresentationConnection",
+          "status": "FAIL",
+          "message": "assert_equals: receive a string correctly expected \"1st\" but got \"1st2nd\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html",
+      "subtests": [
+        {
+          "name": "Terminating a presentation in a controlling browsing context",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: \"The presentation is not terminated successfully when the presentation connection in \\\"connecting\\\" state.\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html",
+      "subtests": [
+        {
+          "name": "Sending a message through PresentationConnection",
+          "status": "FAIL",
+          "message": "assert_true: Not expecting event, but got close event expected true got false"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html",
+      "subtests": [
+        {
+          "name": "Firing a connectionavailable event at a controlling user agent",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/defaultRequest_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "[Optional] Starting a presentation from the browser using a default presentation request.",
+          "status": "FAIL",
+          "message": "assert_unreached: This browser does not support defaultRequest. Reached unreachable code"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Reconnect to presentation success manual test",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: object \"OperationError: The operation failed for an operation-specific reason\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when the user denied permission to use the display returns a Promise rejected with a NotAllowedError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.",
+          "status": "FAIL",
+          "message": "assert_throws: function \"function() { throw e }\" threw object \"NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.\" that is not a DOMException NotFoundError: property \"code\" is equal to 0, expected 8"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Sandboxing: starting a presentation from a nested context succeeds when allow-presentation is set",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_success-manual.https.html",
+      "subtests": [
+        {
+          "name": "Checking the chain of events when starting a new presentation",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html",
+      "subtests": [
+        {
+          "name": "Calling \"start\" when there is already an unsettled Promise returns a Promise rejected with an OperationError exception.",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/presentation-api/controlling-ua/all.html
+++ b/presentation-api/controlling-ua/all.html
@@ -11,7 +11,8 @@
       <header>
         <h1>Presentation API - Controlling UA: All Results</h1>
       </header>
-      <p><strong>Test files</strong>: 27; <strong>Total subtests</strong>: 106</p>
+      
+      <p><strong>Test files</strong>: 27; <strong>Total subtests</strong>: 108</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/presentation-api/controlling-ua/PresentationRequest_error.https.html</a></li>
 <li><a href='#test-file-1'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html</a></li>
@@ -42,144 +43,149 @@
 <li><a href='#test-file-26'>/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html</a></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>CA61</th><th>CD59</th><th>FA56</th></tr></thead>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>CA63</th><th>CD63</th><th>FA57</th></tr></thead>
 <tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_error.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_error.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Call PresentationRequest() constructor without presentation URL. TypeError Exception expected.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Call PresentationRequest constructor with an empty sequence. NotSupportedError Exception expected.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-0-3' class='subtest'><td>Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-0-1' class='subtest'><td>Call PresentationRequest constructor with an empty sequence. NotSupportedError Exception expected.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-0-2' class='subtest'><td>Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-0-0' class='subtest'><td>Call PresentationRequest() constructor without presentation URL. TypeError Exception expected.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Creating a PresentationRequest with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-1-0' class='subtest'><td>Creating a PresentationRequest with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Creating a PresentationRequest with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-2-0' class='subtest'><td>Creating a PresentationRequest with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_sandboxing_error.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_sandboxing_error.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sandboxing: Creating a PresentationRequest from a nested context fails when allow-presentation is not set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-3-0' class='subtest'><td>Sandboxing: Creating a PresentationRequest from a nested context fails when allow-presentation is not set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_sandboxing_success.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_sandboxing_success.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sandboxing: Creating a PresentationRequest from a nested context succeeds when allow-presentation is set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-4-0' class='subtest'><td>Sandboxing: Creating a PresentationRequest from a nested context succeeds when allow-presentation is set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_success.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_success.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Constructing a PresentationRequest</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-5-0' class='subtest'><td>Constructing a PresentationRequest</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/defaultRequest.https.html' target='_blank'>/presentation-api/controlling-ua/defaultRequest.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Setting a default presentation request</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-0' class='subtest'><td>Setting a default presentation request</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/getAvailability.https.html' target='_blank'>/presentation-api/controlling-ua/getAvailability.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Getting the presentation displays availability information.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-7-0' class='subtest'><td>Getting the presentation displays availability information.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/getAvailability_sandboxing_success.https.html' target='_blank'>/presentation-api/controlling-ua/getAvailability_sandboxing_success.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sandboxing: Retrieving display availability from a nested context succeeds when allow-presentation is set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-8-0' class='subtest'><td>Sandboxing: Retrieving display availability from a nested context succeeds when allow-presentation is set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/idlharness.https.html' target='_blank'>/presentation-api/controlling-ua/idlharness.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Navigator interface: attribute presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: attribute defaultRequest</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation must be primary interface of navigator.presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Stringification of navigator.presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: navigator.presentation must inherit property "defaultRequest" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: operation start()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: operation reconnect(USVString)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: operation getAvailability()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: attribute onconnectionavailable</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest must be primary interface of navigator.presentation.defaultRequest</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Stringification of navigator.presentation.defaultRequest</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: navigator.presentation.defaultRequest must inherit property "start" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: navigator.presentation.defaultRequest must inherit property "reconnect" with the proper type (1)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: calling reconnect(USVString) on navigator.presentation.defaultRequest with too few arguments must throw TypeError</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: navigator.presentation.defaultRequest must inherit property "getAvailability" with the proper type (2)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: navigator.presentation.defaultRequest must inherit property "onconnectionavailable" with the proper type (3)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest must be primary interface of presentation_request</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Stringification of presentation_request</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: presentation_request must inherit property "start" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: presentation_request must inherit property "reconnect" with the proper type (1)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: calling reconnect(USVString) on presentation_request with too few arguments must throw TypeError</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: presentation_request must inherit property "getAvailability" with the proper type (2)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: presentation_request must inherit property "onconnectionavailable" with the proper type (3)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest must be primary interface of presentation_request_urls</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Stringification of presentation_request_urls</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: presentation_request_urls must inherit property "start" with the proper type (0)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: presentation_request_urls must inherit property "reconnect" with the proper type (1)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: calling reconnect(USVString) on presentation_request_urls with too few arguments must throw TypeError</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: presentation_request_urls must inherit property "getAvailability" with the proper type (2)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationRequest interface: presentation_request_urls must inherit property "onconnectionavailable" with the proper type (3)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationAvailability interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationAvailability interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationAvailability interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationAvailability interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationAvailability interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationAvailability interface: attribute value</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationAvailability interface: attribute onchange</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: attribute connection</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute id</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute url</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute state</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation close()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation terminate()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onconnect</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onclose</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onterminate</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute binaryType</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onmessage</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation send(DOMString)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation send(Blob)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation send(ArrayBuffer)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation send(ArrayBufferView)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: attribute reason</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: attribute message</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-0' class='subtest'><td>Navigator interface: attribute presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-2' class='subtest'><td>Presentation interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-3' class='subtest'><td>Presentation interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-6' class='subtest'><td>Presentation interface: attribute defaultRequest</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-1' class='subtest'><td>Presentation interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-4' class='subtest'><td>Presentation interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-5' class='subtest'><td>Presentation interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-9' class='subtest'><td>Presentation interface: navigator.presentation must inherit property "defaultRequest" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-7' class='subtest'><td>Presentation must be primary interface of navigator.presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-41' class='subtest'><td>PresentationAvailability interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-42' class='subtest'><td>PresentationAvailability interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-46' class='subtest'><td>PresentationAvailability interface: attribute onchange</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-45' class='subtest'><td>PresentationAvailability interface: attribute value</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-40' class='subtest'><td>PresentationAvailability interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-43' class='subtest'><td>PresentationAvailability interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-44' class='subtest'><td>PresentationAvailability interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-54' class='subtest'><td>PresentationConnection interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-55' class='subtest'><td>PresentationConnection interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-66' class='subtest'><td>PresentationConnection interface: attribute binaryType</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-58' class='subtest'><td>PresentationConnection interface: attribute id</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-64' class='subtest'><td>PresentationConnection interface: attribute onclose</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-63' class='subtest'><td>PresentationConnection interface: attribute onconnect</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-67' class='subtest'><td>PresentationConnection interface: attribute onmessage</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-65' class='subtest'><td>PresentationConnection interface: attribute onterminate</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-60' class='subtest'><td>PresentationConnection interface: attribute state</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-59' class='subtest'><td>PresentationConnection interface: attribute url</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-53' class='subtest'><td>PresentationConnection interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-56' class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-57' class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-61' class='subtest'><td>PresentationConnection interface: operation close()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-70' class='subtest'><td>PresentationConnection interface: operation send(ArrayBuffer)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-71' class='subtest'><td>PresentationConnection interface: operation send(ArrayBufferView)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-69' class='subtest'><td>PresentationConnection interface: operation send(Blob)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-68' class='subtest'><td>PresentationConnection interface: operation send(DOMString)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-62' class='subtest'><td>PresentationConnection interface: operation terminate()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-48' class='subtest'><td>PresentationConnectionAvailableEvent interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-49' class='subtest'><td>PresentationConnectionAvailableEvent interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-52' class='subtest'><td>PresentationConnectionAvailableEvent interface: attribute connection</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-47' class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-50' class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-51' class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-73' class='subtest'><td>PresentationConnectionCloseEvent interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-74' class='subtest'><td>PresentationConnectionCloseEvent interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-78' class='subtest'><td>PresentationConnectionCloseEvent interface: attribute message</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-77' class='subtest'><td>PresentationConnectionCloseEvent interface: attribute reason</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-72' class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-75' class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-76' class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-11' class='subtest'><td>PresentationRequest interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-12' class='subtest'><td>PresentationRequest interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-18' class='subtest'><td>PresentationRequest interface: attribute onconnectionavailable</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-23' class='subtest'><td>PresentationRequest interface: calling reconnect(USVString) on navigator.presentation.defaultRequest with too few arguments must throw TypeError</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-30' class='subtest'><td>PresentationRequest interface: calling reconnect(USVString) on presentation_request with too few arguments must throw TypeError</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-37' class='subtest'><td>PresentationRequest interface: calling reconnect(USVString) on presentation_request_urls with too few arguments must throw TypeError</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-10' class='subtest'><td>PresentationRequest interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-13' class='subtest'><td>PresentationRequest interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-14' class='subtest'><td>PresentationRequest interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-24' class='subtest'><td>PresentationRequest interface: navigator.presentation.defaultRequest must inherit property "getAvailability()" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-25' class='subtest'><td>PresentationRequest interface: navigator.presentation.defaultRequest must inherit property "onconnectionavailable" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-22' class='subtest'><td>PresentationRequest interface: navigator.presentation.defaultRequest must inherit property "reconnect(USVString)" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-21' class='subtest'><td>PresentationRequest interface: navigator.presentation.defaultRequest must inherit property "start()" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-17' class='subtest'><td>PresentationRequest interface: operation getAvailability()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-16' class='subtest'><td>PresentationRequest interface: operation reconnect(USVString)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-15' class='subtest'><td>PresentationRequest interface: operation start()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-31' class='subtest'><td>PresentationRequest interface: presentation_request must inherit property "getAvailability()" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-32' class='subtest'><td>PresentationRequest interface: presentation_request must inherit property "onconnectionavailable" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-29' class='subtest'><td>PresentationRequest interface: presentation_request must inherit property "reconnect(USVString)" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-28' class='subtest'><td>PresentationRequest interface: presentation_request must inherit property "start()" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-38' class='subtest'><td>PresentationRequest interface: presentation_request_urls must inherit property "getAvailability()" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-39' class='subtest'><td>PresentationRequest interface: presentation_request_urls must inherit property "onconnectionavailable" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-36' class='subtest'><td>PresentationRequest interface: presentation_request_urls must inherit property "reconnect(USVString)" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-35' class='subtest'><td>PresentationRequest interface: presentation_request_urls must inherit property "start()" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-19' class='subtest'><td>PresentationRequest must be primary interface of navigator.presentation.defaultRequest</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-26' class='subtest'><td>PresentationRequest must be primary interface of presentation_request</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-33' class='subtest'><td>PresentationRequest must be primary interface of presentation_request_urls</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-8' class='subtest'><td>Stringification of navigator.presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-20' class='subtest'><td>Stringification of navigator.presentation.defaultRequest</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-27' class='subtest'><td>Stringification of presentation_request</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-9-34' class='subtest'><td>Stringification of presentation_request_urls</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/reconnectToPresentation_notfound_error.https.html' target='_blank'>/presentation-api/controlling-ua/reconnectToPresentation_notfound_error.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Calling "reconnect" with an unknown presentation ID fails with a NotFoundError exception</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-10-0' class='subtest'><td>Calling "reconnect" with an unknown presentation ID fails with a NotFoundError exception</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_success.https.html' target='_blank'>/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_success.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sandboxing: Reconnecting a presentation from a nested context succeeds when allow-presentation is set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-11-0' class='subtest'><td>Sandboxing: Reconnecting a presentation from a nested context succeeds when allow-presentation is set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_error.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_error.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>The presentation could not start, because a user gesture is required.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-12-0' class='subtest'><td>The presentation could not start, because a user gesture is required.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-13-0' class='subtest'><td>Monitoring the list of available presentation displays.</td><td class='TIMEOUT'>TIMEOUT</td><td class='TIMEOUT'>TIMEOUT</td><td class='TIMEOUT'>TIMEOUT</td></tr>
 <tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-14-0' class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onconnect-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onconnect-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Establishing a presentation connection</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-15-0' class='subtest'><td>Establishing a presentation connection</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Receiving a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-16-0' class='subtest'><td>Receiving a message through PresentationConnection</td><td class='TIMEOUT'>TIMEOUT</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Terminating a presentation in a controlling browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-17-0' class='subtest'><td>Terminating a presentation in a controlling browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sending a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-18-0' class='subtest'><td>Sending a message through PresentationConnection</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Firing a connectionavailable event at a controlling user agent</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-19-0' class='subtest'><td>Firing a connectionavailable event at a controlling user agent</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/defaultRequest_success-manual.https.html' target='_blank'>/presentation-api/controlling-ua/defaultRequest_success-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>[Optional] Starting a presentation from the browser using a default presentation request.</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-20-0' class='subtest'><td>[Optional] Starting a presentation from the browser using a default presentation request.</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html' target='_blank'>/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-21-0' class='subtest'><td>Reconnect to presentation success manual test</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-22'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Calling "start" when the user denied permission to use the display returns a Promise rejected with a NotAllowedError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-22-0' class='subtest'><td>Calling "start" when the user denied permission to use the display returns a Promise rejected with a NotAllowedError exception.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Calling "start" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-23-0' class='subtest'><td>Calling "start" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sandboxing: starting a presentation from a nested context succeeds when allow-presentation is set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-24-0' class='subtest'><td>Sandboxing: starting a presentation from a nested context succeeds when allow-presentation is set</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_success-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_success-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Checking the chain of events when starting a new presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-25-0' class='subtest'><td>Checking the chain of events when starting a new presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-26'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Calling "start" when there is already an unsettled Promise returns a Promise rejected with an OperationError exception.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-26-0' class='subtest'><td>Calling "start" when there is already an unsettled Promise returns a Promise rejected with an OperationError exception.</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
+    <script type='application/javascript'>
+      
+    </script>
   </body>
 </html>

--- a/presentation-api/controlling-ua/analysis.css
+++ b/presentation-api/controlling-ua/analysis.css
@@ -1,23 +1,27 @@
+a {
+  color: hsl(213, 65%, 48%);
+}
+
 
 th {
     text-align: left;
-    background: #4a89dc;
+    background: hsl(213, 65%, 48%);
     color:      #fff;
 }
 
 td.FAIL {
-    background: #da4453;
+    background: hsl(353, 65%, 52%);
     color:      #fff;
 }
 
 td.PASS {
-    background: #37bc9b;
+    background: hsl(165, 50%, 35%);
     color:      #fff;
 }
 
 td.NOTRUN, td.TIMEOUT, td.undefined {
     background: #f6bb42;
-    color:  #fff;
+    color:  hsl(219, 8%, 33%);
 }
 
 table > tbody > tr > td.NOTRUN, table > tbody > tr > td.TIMEOUT {
@@ -53,10 +57,28 @@ tr.subtest > td:first-of-type {
     white-space:    nowrap;
 }
 
+tr.messages > td:first-of-type {
+    width: 100%;
+    padding-left:   2em;
+}
+
+tr.message > td.ua {
+  font-weight: bold;
+  vertical-align: top;
+  padding-right: 1em;
+}
+
 .floatingHeader {
     position: fixed;
     top: 0;
     visibility: hidden;
+}
+
+.message_toggle {
+  padding-left: 3em;
+  display: none;
+  font-size: 0.7em;
+  cursor: pointer;
 }
 
 dd {

--- a/presentation-api/controlling-ua/complete-fails.html
+++ b/presentation-api/controlling-ua/complete-fails.html
@@ -11,36 +11,40 @@
       <header>
         <h1>Presentation API - Controlling UA: Complete Failures</h1>
       </header>
-      <p><strong>Completely failed files</strong>: 10; <strong>Completely failed subtests</strong>: 7; <strong>Failure level</strong>: 7/106 (6.60%)</p>
+      
+      <p><strong>Completely failed files</strong>: 9; <strong>Completely failed subtests</strong>: 7; <strong>Failure level</strong>: 7/108 (6.48%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-1'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-2'>/presentation-api/controlling-ua/getAvailability.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-3'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-4'>/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-5'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-6'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/presentation-api/controlling-ua/getAvailability.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-1'>/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-2'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-3'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-4'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-5'>/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-6'>/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>CA61</th><th>CD59</th><th>FA56</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Creating a PresentationRequest with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Creating a PresentationRequest with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/getAvailability.https.html' target='_blank'>/presentation-api/controlling-ua/getAvailability.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Getting the presentation displays availability information.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Receiving a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Terminating a presentation in a controlling browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sending a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td></tr>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>CA63</th><th>CD63</th><th>FA57</th></tr></thead>
+<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/getAvailability.https.html' target='_blank'>/presentation-api/controlling-ua/getAvailability.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-7-0' class='subtest'><td>Getting the presentation displays availability information.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-13-0' class='subtest'><td>Monitoring the list of available presentation displays.</td><td class='TIMEOUT'>TIMEOUT</td><td class='TIMEOUT'>TIMEOUT</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-14-0' class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-17-0' class='subtest'><td>Terminating a presentation in a controlling browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-18-0' class='subtest'><td>Sending a message through PresentationConnection</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html' target='_blank'>/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-21-0' class='subtest'><td>Reconnect to presentation success manual test</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-23-0' class='subtest'><td>Calling "start" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
+    <script type='application/javascript'>
+      
+    </script>
   </body>
 </html>

--- a/presentation-api/controlling-ua/consolidated.json
+++ b/presentation-api/controlling-ua/consolidated.json
@@ -1,56 +1,65 @@
 {
   "ua": [
-    "CA61",
-    "CD59",
-    "FA56"
+    "CA63",
+    "CD63",
+    "FA57"
   ],
   "results": {
     "/presentation-api/controlling-ua/PresentationRequest_error.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Call PresentationRequest() constructor without presentation URL. TypeError Exception expected.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Call PresentationRequest constructor with an empty sequence. NotSupportedError Exception expected.": {
+          "stNum": 1,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.": {
+          "stNum": 2,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.": {
+          "stNum": 3,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -59,63 +68,80 @@
     },
     "/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Creating a PresentationRequest with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "FAIL",
-            "FA56": "FAIL"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "FA57": "assert_throws: function \"function createPresentation() {\n        var request = new PresentationRequest('http://example.org/presentation.html');\n    }\" did not throw"
           },
           "totals": {
-            "FAIL": 3
+            "PASS": 2,
+            "FAIL": 1
           }
         }
       }
     },
     "/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Creating a PresentationRequest with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "FAIL",
-            "FA56": "FAIL"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "FA57": "assert_throws: function \"function createPresentation() {\n        var request = new PresentationRequest([\n          'presentation.html',\n          'http://example.org/presentation.html'\n        ]);\n    }\" did not throw"
           },
           "totals": {
-            "FAIL": 3
+            "PASS": 2,
+            "FAIL": 1
           }
         }
       }
     },
     "/presentation-api/controlling-ua/PresentationRequest_sandboxing_error.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Sandboxing: Creating a PresentationRequest from a nested context fails when allow-presentation is not set": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "FAIL"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "FA57": "assert_equals: Presentation sandboxing did not work as expected. expected \"SecurityError\" but got \"success\""
           },
           "totals": {
             "PASS": 2,
@@ -126,20 +152,23 @@
     },
     "/presentation-api/controlling-ua/PresentationRequest_sandboxing_success.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Sandboxing: Creating a PresentationRequest from a nested context succeeds when allow-presentation is set": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -148,20 +177,23 @@
     },
     "/presentation-api/controlling-ua/PresentationRequest_success.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Constructing a PresentationRequest": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -170,20 +202,23 @@
     },
     "/presentation-api/controlling-ua/defaultRequest.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Setting a default presentation request": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -192,19 +227,26 @@
     },
     "/presentation-api/controlling-ua/getAvailability.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Getting the presentation displays availability information.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "FAIL",
-            "FA56": "FAIL"
+            "CA63": "FAIL",
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CA63": "assert_not_equals: If the Promise from a previous call to getAvailability has already been settled, getAvailability returns a new Promise. got disallowed value object \"[object Promise]\"",
+            "CD63": "assert_not_equals: If the Promise from a previous call to getAvailability has already been settled, getAvailability returns a new Promise. got disallowed value object \"[object Promise]\"",
+            "FA57": "assert_equals: If the PresentationRequest object has an unsettled Promise, getAvailability returns that Promise. expected object \"[object Promise]\" but got object \"[object Promise]\""
           },
           "totals": {
             "FAIL": 3
@@ -214,20 +256,23 @@
     },
     "/presentation-api/controlling-ua/getAvailability_sandboxing_success.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Sandboxing: Retrieving display availability from a nested context succeeds when allow-presentation is set": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -236,800 +281,959 @@
     },
     "/presentation-api/controlling-ua/idlharness.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Navigator interface: attribute presentation": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Presentation interface: existence and properties of interface object": {
+          "stNum": 1,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Presentation interface object length": {
+          "stNum": 2,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Presentation interface object name": {
+          "stNum": 3,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Presentation interface: existence and properties of interface prototype object": {
+          "stNum": 4,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Presentation interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 5,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Presentation interface: attribute defaultRequest": {
+          "stNum": 6,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Presentation must be primary interface of navigator.presentation": {
+          "stNum": 7,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Stringification of navigator.presentation": {
+          "stNum": 8,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "Presentation interface: navigator.presentation must inherit property \"defaultRequest\" with the proper type (0)": {
+        "Presentation interface: navigator.presentation must inherit property \"defaultRequest\" with the proper type": {
+          "stNum": 9,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: existence and properties of interface object": {
+          "stNum": 10,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface object length": {
+          "stNum": 11,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface object name": {
+          "stNum": 12,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: existence and properties of interface prototype object": {
+          "stNum": 13,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 14,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: operation start()": {
+          "stNum": 15,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: operation reconnect(USVString)": {
+          "stNum": 16,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: operation getAvailability()": {
+          "stNum": 17,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: attribute onconnectionavailable": {
+          "stNum": 18,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest must be primary interface of navigator.presentation.defaultRequest": {
+          "stNum": 19,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Stringification of navigator.presentation.defaultRequest": {
+          "stNum": 20,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"start\" with the proper type (0)": {
+        "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"start()\" with the proper type": {
+          "stNum": 21,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"reconnect\" with the proper type (1)": {
+        "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"reconnect(USVString)\" with the proper type": {
+          "stNum": 22,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: calling reconnect(USVString) on navigator.presentation.defaultRequest with too few arguments must throw TypeError": {
+          "stNum": 23,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"getAvailability\" with the proper type (2)": {
+        "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"getAvailability()\" with the proper type": {
+          "stNum": 24,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"onconnectionavailable\" with the proper type (3)": {
+        "PresentationRequest interface: navigator.presentation.defaultRequest must inherit property \"onconnectionavailable\" with the proper type": {
+          "stNum": 25,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest must be primary interface of presentation_request": {
+          "stNum": 26,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Stringification of presentation_request": {
+          "stNum": 27,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: presentation_request must inherit property \"start\" with the proper type (0)": {
+        "PresentationRequest interface: presentation_request must inherit property \"start()\" with the proper type": {
+          "stNum": 28,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: presentation_request must inherit property \"reconnect\" with the proper type (1)": {
+        "PresentationRequest interface: presentation_request must inherit property \"reconnect(USVString)\" with the proper type": {
+          "stNum": 29,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: calling reconnect(USVString) on presentation_request with too few arguments must throw TypeError": {
+          "stNum": 30,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: presentation_request must inherit property \"getAvailability\" with the proper type (2)": {
+        "PresentationRequest interface: presentation_request must inherit property \"getAvailability()\" with the proper type": {
+          "stNum": 31,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: presentation_request must inherit property \"onconnectionavailable\" with the proper type (3)": {
+        "PresentationRequest interface: presentation_request must inherit property \"onconnectionavailable\" with the proper type": {
+          "stNum": 32,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest must be primary interface of presentation_request_urls": {
+          "stNum": 33,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "Stringification of presentation_request_urls": {
+          "stNum": 34,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: presentation_request_urls must inherit property \"start\" with the proper type (0)": {
+        "PresentationRequest interface: presentation_request_urls must inherit property \"start()\" with the proper type": {
+          "stNum": 35,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: presentation_request_urls must inherit property \"reconnect\" with the proper type (1)": {
+        "PresentationRequest interface: presentation_request_urls must inherit property \"reconnect(USVString)\" with the proper type": {
+          "stNum": 36,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationRequest interface: calling reconnect(USVString) on presentation_request_urls with too few arguments must throw TypeError": {
+          "stNum": 37,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: presentation_request_urls must inherit property \"getAvailability\" with the proper type (2)": {
+        "PresentationRequest interface: presentation_request_urls must inherit property \"getAvailability()\" with the proper type": {
+          "stNum": 38,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
-        "PresentationRequest interface: presentation_request_urls must inherit property \"onconnectionavailable\" with the proper type (3)": {
+        "PresentationRequest interface: presentation_request_urls must inherit property \"onconnectionavailable\" with the proper type": {
+          "stNum": 39,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationAvailability interface: existence and properties of interface object": {
+          "stNum": 40,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationAvailability interface object length": {
+          "stNum": 41,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationAvailability interface object name": {
+          "stNum": 42,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationAvailability interface: existence and properties of interface prototype object": {
+          "stNum": 43,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationAvailability interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 44,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationAvailability interface: attribute value": {
+          "stNum": 45,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationAvailability interface: attribute onchange": {
+          "stNum": 46,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionAvailableEvent interface: existence and properties of interface object": {
+          "stNum": 47,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionAvailableEvent interface object length": {
+          "stNum": 48,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionAvailableEvent interface object name": {
+          "stNum": 49,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object": {
+          "stNum": 50,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 51,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionAvailableEvent interface: attribute connection": {
+          "stNum": 52,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: existence and properties of interface object": {
+          "stNum": 53,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface object length": {
+          "stNum": 54,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface object name": {
+          "stNum": 55,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: existence and properties of interface prototype object": {
+          "stNum": 56,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 57,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: attribute id": {
+          "stNum": 58,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: attribute url": {
+          "stNum": 59,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: attribute state": {
+          "stNum": 60,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: operation close()": {
+          "stNum": 61,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: operation terminate()": {
+          "stNum": 62,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: attribute onconnect": {
+          "stNum": 63,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: attribute onclose": {
+          "stNum": 64,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: attribute onterminate": {
+          "stNum": 65,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: attribute binaryType": {
+          "stNum": 66,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: attribute onmessage": {
+          "stNum": 67,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: operation send(DOMString)": {
+          "stNum": 68,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: operation send(Blob)": {
+          "stNum": 69,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: operation send(ArrayBuffer)": {
+          "stNum": 70,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnection interface: operation send(ArrayBufferView)": {
+          "stNum": 71,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionCloseEvent interface: existence and properties of interface object": {
+          "stNum": 72,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionCloseEvent interface object length": {
+          "stNum": 73,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionCloseEvent interface object name": {
+          "stNum": 74,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object": {
+          "stNum": 75,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 76,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionCloseEvent interface: attribute reason": {
+          "stNum": 77,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "PresentationConnectionCloseEvent interface: attribute message": {
+          "stNum": 78,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -1038,20 +1242,23 @@
     },
     "/presentation-api/controlling-ua/reconnectToPresentation_notfound_error.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Calling \"reconnect\" with an unknown presentation ID fails with a NotFoundError exception": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -1060,20 +1267,23 @@
     },
     "/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_success.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Sandboxing: Reconnecting a presentation from a nested context succeeds when allow-presentation is set": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -1082,19 +1292,24 @@
     },
     "/presentation-api/controlling-ua/startNewPresentation_error.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "The presentation could not start, because a user gesture is required.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "FAIL"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "FA57": "assert_unreached: Should have rejected: undefined Reached unreachable code"
           },
           "totals": {
             "PASS": 2,
@@ -1105,42 +1320,51 @@
     },
     "/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Monitoring the list of available presentation displays.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "TIMEOUT",
-            "FA56": "TIMEOUT"
+            "CA63": "TIMEOUT",
+            "CD63": "TIMEOUT",
+            "FA57": "TIMEOUT"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 1,
-            "TIMEOUT": 2
+            "TIMEOUT": 3
           }
         }
       }
     },
     "/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Closing a PresentationConnection": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "FAIL",
-            "FA56": "FAIL"
+            "CA63": "FAIL",
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CA63": "assert_equals: Expected close event, but got connect event instead expected \"close\" but got \"connect\"",
+            "CD63": "promise_test: Unhandled rejection with value: \"The presentation connection in \\\"connecting\\\" state was not closed successfully.\"",
+            "FA57": "promise_test: Unhandled rejection with value: object \"OperationError: The operation failed for an operation-specific reason\""
           },
           "totals": {
             "FAIL": 3
@@ -1150,20 +1374,23 @@
     },
     "/presentation-api/controlling-ua/PresentationConnection_onconnect-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Establishing a presentation connection": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -1172,42 +1399,55 @@
     },
     "/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Receiving a message through PresentationConnection": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "TIMEOUT",
-            "FA56": "FAIL"
+            "CA63": "TIMEOUT",
+            "CD63": "PASS",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "FA57": "assert_equals: receive a string correctly expected \"1st\" but got \"1st2nd\""
           },
           "totals": {
-            "FAIL": 2,
-            "TIMEOUT": 1
+            "TIMEOUT": 1,
+            "PASS": 1,
+            "FAIL": 1
           }
         }
       }
     },
     "/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Terminating a presentation in a controlling browsing context": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "FAIL",
-            "FA56": "FAIL"
+            "CA63": "FAIL",
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CA63": "promise_test: Unhandled rejection with value: \"The presentation is not terminated successfully when the presentation connection in \\\"connecting\\\" state.\"",
+            "CD63": "promise_test: Unhandled rejection with value: \"The presentation is not terminated successfully when the presentation connection in \\\"connecting\\\" state.\"",
+            "FA57": "promise_test: Unhandled rejection with value: \"The presentation is not terminated successfully when the presentation connection in \\\"connecting\\\" state.\""
           },
           "totals": {
             "FAIL": 3
@@ -1217,65 +1457,79 @@
     },
     "/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Sending a message through PresentationConnection": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "TIMEOUT",
-            "FA56": "FAIL"
+            "CA63": "TIMEOUT",
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CD63": "assert_equals: Expected connect event, but got close event instead expected \"connect\" but got \"close\"",
+            "FA57": "assert_true: Not expecting event, but got close event expected true got false"
           },
           "totals": {
-            "FAIL": 2,
-            "TIMEOUT": 1
+            "TIMEOUT": 1,
+            "FAIL": 2
           }
         }
       }
     },
     "/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Firing a connectionavailable event at a controlling user agent": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "FAIL",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 1
+            "PASS": 3
           }
         }
       }
     },
     "/presentation-api/controlling-ua/defaultRequest_success-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "[Optional] Starting a presentation from the browser using a default presentation request.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "PASS",
-            "FA56": "FAIL"
+            "CA63": "FAIL",
+            "CD63": "PASS",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CA63": "assert_unreached: This browser does not support defaultRequest. Reached unreachable code",
+            "FA57": "assert_unreached: This browser does not support defaultRequest. Reached unreachable code"
           },
           "totals": {
             "FAIL": 2,
@@ -1286,89 +1540,106 @@
     },
     "/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Reconnect to presentation success manual test": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "TIMEOUT",
-            "CD59": "TIMEOUT",
-            "FA56": "FAIL"
+            "CA63": "FAIL",
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CA63": "promise_test: Unhandled rejection with value: object \"NotFoundError: Route not found.\"",
+            "CD63": "assert_equals: Expected connect event, but got close event instead expected \"connect\" but got \"close\"",
+            "FA57": "promise_test: Unhandled rejection with value: object \"OperationError: The operation failed for an operation-specific reason\""
           },
           "totals": {
-            "TIMEOUT": 2,
-            "FAIL": 1
+            "FAIL": 3
           }
         }
       }
     },
     "/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Calling \"start\" when the user denied permission to use the display returns a Promise rejected with a NotAllowedError exception.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "FAIL",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
-            "PASS": 1
+            "PASS": 3
           }
         }
       }
     },
     "/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Calling \"start\" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "FAIL",
-            "CD59": "PASS",
-            "FA56": "FAIL"
+            "CA63": "FAIL",
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CA63": "assert_throws: function \"function () { throw e }\" threw object \"NotAllowedError: Dialog closed.\" that is not a DOMException NotFoundError: property \"code\" is equal to 0, expected 8",
+            "CD63": "assert_throws: function \"function () { throw e }\" threw object \"NotAllowedError: Dialog closed.\" that is not a DOMException NotFoundError: property \"code\" is equal to 0, expected 8",
+            "FA57": "assert_throws: function \"function() { throw e }\" threw object \"NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.\" that is not a DOMException NotFoundError: property \"code\" is equal to 0, expected 8"
           },
           "totals": {
-            "FAIL": 2,
-            "PASS": 1
+            "FAIL": 3
           }
         }
       }
     },
     "/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Sandboxing: starting a presentation from a nested context succeeds when allow-presentation is set": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -1377,20 +1648,23 @@
     },
     "/presentation-api/controlling-ua/startNewPresentation_success-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Checking the chain of events when starting a new presentation": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -1399,20 +1673,23 @@
     },
     "/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.https.html": {
       "byUA": {
-        "CA61": "OK",
-        "CD59": "OK",
-        "FA56": "OK"
+        "CA63": "OK",
+        "CD63": "OK",
+        "FA57": "OK"
       },
+      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "Calling \"start\" when there is already an unsettled Promise returns a Promise rejected with an OperationError exception.": {
+          "stNum": 0,
           "byUA": {
-            "CA61": "PASS",
-            "CD59": "PASS",
-            "FA56": "PASS"
+            "CA63": "PASS",
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
             "PASS": 3
           }

--- a/presentation-api/controlling-ua/less-than-2.html
+++ b/presentation-api/controlling-ua/less-than-2.html
@@ -11,45 +11,46 @@
       <header>
         <h1>Presentation API - Controlling UA: Less Than 2 Passes</h1>
       </header>
-      <p><strong>Test files without 2 passes</strong>: 10; <strong>Subtests without 2 passes: </strong>10; <strong>Failure level</strong>: 10/106 (9.43%)</p>
+      
+      <p><strong>Test files without 2 passes</strong>: 9; <strong>Subtests without 2 passes: </strong>9; <strong>Failure level</strong>: 9/108 (8.33%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-1'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-2'>/presentation-api/controlling-ua/getAvailability.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-3'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-4'>/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-5'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-6'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-7'>/presentation-api/controlling-ua/defaultRequest_success-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-8'>/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
-<li><a href='#test-file-9'>/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/presentation-api/controlling-ua/getAvailability.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-1'>/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-2'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-3'>/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-4'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-5'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-6'>/presentation-api/controlling-ua/defaultRequest_success-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-7'>/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
+<li><a href='#test-file-8'>/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>CA61</th><th>CD59</th><th>FA56</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Creating a PresentationRequest with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationRequest_mixedcontent_multiple.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Creating a PresentationRequest with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/getAvailability.https.html' target='_blank'>/presentation-api/controlling-ua/getAvailability.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Getting the presentation displays availability information.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Receiving a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Terminating a presentation in a controlling browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sending a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/defaultRequest_success-manual.https.html' target='_blank'>/presentation-api/controlling-ua/defaultRequest_success-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>[Optional] Starting a presentation from the browser using a default presentation request.</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Calling "start" when the user denied permission to use the display returns a Promise rejected with a NotAllowedError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html</a> <small>(1/1, 100.00%, 0.94% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Calling "start" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>CA63</th><th>CD63</th><th>FA57</th></tr></thead>
+<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/getAvailability.https.html' target='_blank'>/presentation-api/controlling-ua/getAvailability.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-7-0' class='subtest'><td>Getting the presentation displays availability information.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-13-0' class='subtest'><td>Monitoring the list of available presentation displays.</td><td class='TIMEOUT'>TIMEOUT</td><td class='TIMEOUT'>TIMEOUT</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-14-0' class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-16-0' class='subtest'><td>Receiving a message through PresentationConnection</td><td class='TIMEOUT'>TIMEOUT</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_onterminate-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-17-0' class='subtest'><td>Terminating a presentation in a controlling browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html' target='_blank'>/presentation-api/controlling-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-18-0' class='subtest'><td>Sending a message through PresentationConnection</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/defaultRequest_success-manual.https.html' target='_blank'>/presentation-api/controlling-ua/defaultRequest_success-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-20-0' class='subtest'><td>[Optional] Starting a presentation from the browser using a default presentation request.</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html' target='_blank'>/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-21-0' class='subtest'><td>Reconnect to presentation success manual test</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html' target='_blank'>/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.https.html</a> <small>(1/1, 100.00%, 0.93% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-23-0' class='subtest'><td>Calling "start" when there is no available presentation display returns a Promise rejected with a NotFoundError exception.</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
+    <script type='application/javascript'>
+      
+    </script>
   </body>
 </html>

--- a/presentation-api/receiving-ua/CD63.json
+++ b/presentation-api/receiving-ua/CD63.json
@@ -1,0 +1,373 @@
+{
+  "results": [
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html",
+      "subtests": [
+        {
+          "name": "Monitoring incoming presentation connections",
+          "status": "FAIL",
+          "message": "assert_true: A closed presentation connection is removed from the set of presentation controllers. expected true got false"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html",
+      "subtests": [
+        {
+          "name": "Closing a PresentationConnection",
+          "status": "FAIL",
+          "message": "assert_true: A presentation connection is closed when its controller's browsing context is discarded. expected true got false"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html",
+      "subtests": [
+        {
+          "name": "Receiving a message through PresentationConnection",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html",
+      "subtests": [
+        {
+          "name": "Sending a message through PresentationConnection",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: undefined"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnection_terminate-manual.https.html",
+      "subtests": [
+        {
+          "name": "Terminating a presentation in a receiving browsing context",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html",
+      "subtests": [
+        {
+          "name": "Creating a receiving browsing context",
+          "status": "FAIL",
+          "message": "promise_test: Unhandled rejection with value: \"A receiving user agent unexpectedly closed a presentation. \""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/idlharness-manual.https.html",
+      "subtests": [
+        {
+          "name": "Navigator interface: attribute presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: attribute receiver",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation must be primary interface of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: navigator.presentation must inherit property \"receiver\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: attribute connection",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute id",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute url",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute state",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation close()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation terminate()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onconnect",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onclose",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onterminate",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute binaryType",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onmessage",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(DOMString)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(Blob)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBuffer)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBufferView)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute reason",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute message",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: attribute connectionList",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver must be primary interface of navigator.presentation.receiver",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation.receiver",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: navigator.presentation.receiver must inherit property \"connectionList\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: attribute connections",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: attribute onconnectionavailable",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/presentation-api/receiving-ua/FA57.json
+++ b/presentation-api/receiving-ua/FA57.json
@@ -1,0 +1,366 @@
+{
+  "results": [
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html",
+      "subtests": [
+        {
+          "name": "Monitoring incoming presentation connections",
+          "status": "FAIL",
+          "message": "assert_true: A closed presentation connection is removed from the set of presentation controllers. expected true got false"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html",
+      "subtests": [],
+      "status": "FAIL",
+      "message": ""
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html",
+      "subtests": [
+        {
+          "name": "Receiving a message through PresentationConnection",
+          "status": "FAIL",
+          "message": "assert_equals: receive a string correctly expected \"1st\" but got \"1st2nd\""
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html",
+      "subtests": [
+        {
+          "name": "Sending a message through PresentationConnection",
+          "status": "FAIL",
+          "message": "assert_true: send a string correctly expected true got false"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationConnection_terminate-manual.https.html",
+      "subtests": [
+        {
+          "name": "Terminating a presentation in a receiving browsing context",
+          "status": "TIMEOUT"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html",
+      "subtests": [
+        {
+          "name": "Creating a receiving browsing context",
+          "status": "FAIL",
+          "message": "assert_unreached: Top-level navigation is disabled. Reached unreachable code"
+        }
+      ],
+      "status": "OK",
+      "message": null
+    },
+    {
+      "test": "/presentation-api/receiving-ua/idlharness-manual.https.html",
+      "subtests": [
+        {
+          "name": "Navigator interface: attribute presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: attribute receiver",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation must be primary interface of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Presentation interface: navigator.presentation must inherit property \"receiver\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionAvailableEvent interface: attribute connection",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute id",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute url",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute state",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation close()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation terminate()",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onconnect",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onclose",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onterminate",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute binaryType",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: attribute onmessage",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(DOMString)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(Blob)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBuffer)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnection interface: operation send(ArrayBufferView)",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute reason",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionCloseEvent interface: attribute message",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: attribute connectionList",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver must be primary interface of navigator.presentation.receiver",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "Stringification of navigator.presentation.receiver",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationReceiver interface: navigator.presentation.receiver must inherit property \"connectionList\" with the proper type",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: existence and properties of interface object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface object length",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface object name",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: existence and properties of interface prototype object",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: existence and properties of interface prototype object's \"constructor\" property",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: attribute connections",
+          "status": "PASS",
+          "message": null
+        },
+        {
+          "name": "PresentationConnectionList interface: attribute onconnectionavailable",
+          "status": "PASS",
+          "message": null
+        }
+      ],
+      "status": "OK",
+      "message": null
+    }
+  ]
+}

--- a/presentation-api/receiving-ua/all.html
+++ b/presentation-api/receiving-ua/all.html
@@ -11,6 +11,7 @@
       <header>
         <h1>Presentation API - Receiving UA: All Results</h1>
       </header>
+      
       <p><strong>Test files</strong>: 7; <strong>Total subtests</strong>: 64</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html</a></li>
@@ -22,82 +23,85 @@
 <li><a href='#test-file-6'>/presentation-api/receiving-ua/idlharness-manual.https.html</a></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>CD59</th><th>FA56</th></tr></thead>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>CD63</th><th>FA57</th></tr></thead>
 <tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Monitoring incoming presentation connections</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr id='subtest-0-0' class='subtest'><td>Monitoring incoming presentation connections</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html</a></td><td class='OK'>OK</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-1-0' class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Receiving a message through PresentationConnection</td><td class='TIMEOUT'>TIMEOUT</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-2-0' class='subtest'><td>Receiving a message through PresentationConnection</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Sending a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr id='subtest-3-0' class='subtest'><td>Sending a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_terminate-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_terminate-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Terminating a presentation in a receiving browsing context</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr id='subtest-4-0' class='subtest'><td>Terminating a presentation in a receiving browsing context</td><td class='PASS'>PASS</td><td class='TIMEOUT'>TIMEOUT</td></tr>
 <tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Creating a receiving browsing context</td><td class='FAIL'>FAIL</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr id='subtest-5-0' class='subtest'><td>Creating a receiving browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/idlharness-manual.https.html' target='_blank'>/presentation-api/receiving-ua/idlharness-manual.https.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Navigator interface: attribute presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: attribute receiver</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation must be primary interface of navigator.presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Stringification of navigator.presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Presentation interface: navigator.presentation must inherit property "receiver" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: attribute connection</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute id</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute url</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute state</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation close()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation terminate()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onconnect</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onclose</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onterminate</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute binaryType</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onmessage</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation send(DOMString)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation send(Blob)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation send(ArrayBuffer)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: operation send(ArrayBufferView)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: attribute reason</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionCloseEvent interface: attribute message</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: attribute connectionList</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationReceiver must be primary interface of navigator.presentation.receiver</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>Stringification of navigator.presentation.receiver</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: navigator.presentation.receiver must inherit property "connectionList" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: attribute connections</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: attribute onconnectionavailable</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-0' class='subtest'><td>Navigator interface: attribute presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-2' class='subtest'><td>Presentation interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-3' class='subtest'><td>Presentation interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-6' class='subtest'><td>Presentation interface: attribute receiver</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-1' class='subtest'><td>Presentation interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-4' class='subtest'><td>Presentation interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-5' class='subtest'><td>Presentation interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-9' class='subtest'><td>Presentation interface: navigator.presentation must inherit property "receiver" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-7' class='subtest'><td>Presentation must be primary interface of navigator.presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-17' class='subtest'><td>PresentationConnection interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-18' class='subtest'><td>PresentationConnection interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-29' class='subtest'><td>PresentationConnection interface: attribute binaryType</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-21' class='subtest'><td>PresentationConnection interface: attribute id</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-27' class='subtest'><td>PresentationConnection interface: attribute onclose</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-26' class='subtest'><td>PresentationConnection interface: attribute onconnect</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-30' class='subtest'><td>PresentationConnection interface: attribute onmessage</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-28' class='subtest'><td>PresentationConnection interface: attribute onterminate</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-23' class='subtest'><td>PresentationConnection interface: attribute state</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-22' class='subtest'><td>PresentationConnection interface: attribute url</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-16' class='subtest'><td>PresentationConnection interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-19' class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-20' class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-24' class='subtest'><td>PresentationConnection interface: operation close()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-33' class='subtest'><td>PresentationConnection interface: operation send(ArrayBuffer)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-34' class='subtest'><td>PresentationConnection interface: operation send(ArrayBufferView)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-32' class='subtest'><td>PresentationConnection interface: operation send(Blob)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-31' class='subtest'><td>PresentationConnection interface: operation send(DOMString)</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-25' class='subtest'><td>PresentationConnection interface: operation terminate()</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-11' class='subtest'><td>PresentationConnectionAvailableEvent interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-12' class='subtest'><td>PresentationConnectionAvailableEvent interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-15' class='subtest'><td>PresentationConnectionAvailableEvent interface: attribute connection</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-10' class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-13' class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-14' class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-36' class='subtest'><td>PresentationConnectionCloseEvent interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-37' class='subtest'><td>PresentationConnectionCloseEvent interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-41' class='subtest'><td>PresentationConnectionCloseEvent interface: attribute message</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-40' class='subtest'><td>PresentationConnectionCloseEvent interface: attribute reason</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-35' class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-38' class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-39' class='subtest'><td>PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-52' class='subtest'><td>PresentationConnectionList interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-53' class='subtest'><td>PresentationConnectionList interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-56' class='subtest'><td>PresentationConnectionList interface: attribute connections</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-57' class='subtest'><td>PresentationConnectionList interface: attribute onconnectionavailable</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-51' class='subtest'><td>PresentationConnectionList interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-54' class='subtest'><td>PresentationConnectionList interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-55' class='subtest'><td>PresentationConnectionList interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-43' class='subtest'><td>PresentationReceiver interface object length</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-44' class='subtest'><td>PresentationReceiver interface object name</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-47' class='subtest'><td>PresentationReceiver interface: attribute connectionList</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-42' class='subtest'><td>PresentationReceiver interface: existence and properties of interface object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-45' class='subtest'><td>PresentationReceiver interface: existence and properties of interface prototype object</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-46' class='subtest'><td>PresentationReceiver interface: existence and properties of interface prototype object's "constructor" property</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-50' class='subtest'><td>PresentationReceiver interface: navigator.presentation.receiver must inherit property "connectionList" with the proper type</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-48' class='subtest'><td>PresentationReceiver must be primary interface of navigator.presentation.receiver</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-8' class='subtest'><td>Stringification of navigator.presentation</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr id='subtest-6-49' class='subtest'><td>Stringification of navigator.presentation.receiver</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
+    <script type='application/javascript'>
+      
+    </script>
   </body>
 </html>

--- a/presentation-api/receiving-ua/analysis.css
+++ b/presentation-api/receiving-ua/analysis.css
@@ -1,23 +1,27 @@
+a {
+  color: hsl(213, 65%, 48%);
+}
+
 
 th {
     text-align: left;
-    background: #4a89dc;
+    background: hsl(213, 65%, 48%);
     color:      #fff;
 }
 
 td.FAIL {
-    background: #da4453;
+    background: hsl(353, 65%, 52%);
     color:      #fff;
 }
 
 td.PASS {
-    background: #37bc9b;
+    background: hsl(165, 50%, 35%);
     color:      #fff;
 }
 
 td.NOTRUN, td.TIMEOUT, td.undefined {
     background: #f6bb42;
-    color:  #fff;
+    color:  hsl(219, 8%, 33%);
 }
 
 table > tbody > tr > td.NOTRUN, table > tbody > tr > td.TIMEOUT {
@@ -53,10 +57,28 @@ tr.subtest > td:first-of-type {
     white-space:    nowrap;
 }
 
+tr.messages > td:first-of-type {
+    width: 100%;
+    padding-left:   2em;
+}
+
+tr.message > td.ua {
+  font-weight: bold;
+  vertical-align: top;
+  padding-right: 1em;
+}
+
 .floatingHeader {
     position: fixed;
     top: 0;
     visibility: hidden;
+}
+
+.message_toggle {
+  padding-left: 3em;
+  display: none;
+  font-size: 0.7em;
+  cursor: pointer;
 }
 
 dd {

--- a/presentation-api/receiving-ua/complete-fails.html
+++ b/presentation-api/receiving-ua/complete-fails.html
@@ -11,45 +11,31 @@
       <header>
         <h1>Presentation API - Receiving UA: Complete Failures</h1>
       </header>
-      <p><strong>Completely failed files</strong>: 1; <strong>Completely failed subtests</strong>: 28; <strong>Failure level</strong>: 28/57 (49.12%)</p>
+      
+      <p><strong>Completely failed files</strong>: 6; <strong>Completely failed subtests</strong>: 4; <strong>Failure level</strong>: 4/64 (6.25%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/presentation-api/receiving-ua/idlharness.html</a> <small>(28/57, 49.12%, 49.12% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
+<li><a href='#test-file-1'>/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
+<li><a href='#test-file-2'>/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
+<li><a href='#test-file-3'>/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>CC47</th><th>CC49</th><th>CD53</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/idlharness.html' target='_blank'>/presentation-api/receiving-ua/idlharness.html</a> <small>(28/57, 49.12%, 49.12% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Presentation interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Presentation interface: attribute receiver</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Presentation interface: navigator.presentation must inherit property "receiver" with the proper type (0)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: existence and properties of interface object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface object name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: attribute reason</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: attribute message</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface object name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface prototype object's "constructor" property</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: attribute connectionList</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver must be primary interface of navigator.presentation.receiver</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Stringification of navigator.presentation.receiver</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: navigator.presentation.receiver must inherit property "connectionList" with the proper type (0)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface object name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface prototype object's "constructor" property</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: attribute connections</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: attribute onconnectionavailable</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>CD63</th><th>FA57</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-0-0' class='subtest'><td>Monitoring incoming presentation connections</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-1-0' class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-3-0' class='subtest'><td>Sending a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-5-0' class='subtest'><td>Creating a receiving browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
+    <script type='application/javascript'>
+      
+    </script>
   </body>
 </html>

--- a/presentation-api/receiving-ua/consolidated.json
+++ b/presentation-api/receiving-ua/consolidated.json
@@ -1,592 +1,810 @@
 {
   "ua": [
-    "CC47",
-    "CC49",
-    "CD53"
+    "CD63",
+    "FA57"
   ],
   "results": {
-    "/presentation-api/receiving-ua/idlharness.html": {
+    "/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html": {
       "byUA": {
-        "CC47": "OK",
-        "CC49": "OK",
-        "CD53": "OK"
+        "CD63": "OK",
+        "FA57": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "Monitoring incoming presentation connections": {
+          "stNum": 0,
+          "byUA": {
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CD63": "assert_true: A closed presentation connection is removed from the set of presentation controllers. expected true got false",
+            "FA57": "assert_true: A closed presentation connection is removed from the set of presentation controllers. expected true got false"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        }
+      }
+    },
+    "/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html": {
+      "byUA": {
+        "CD63": "OK",
+        "FA57": "FAIL"
+      },
+      "UAmessage": {
+        "FA57": ""
       },
       "totals": {
-        "OK": 3
+        "OK": 1,
+        "FAIL": 1
+      },
+      "subtests": {
+        "Closing a PresentationConnection": {
+          "stNum": 0,
+          "byUA": {
+            "CD63": "FAIL"
+          },
+          "UAmessage": {
+            "CD63": "assert_true: A presentation connection is closed when its controller's browsing context is discarded. expected true got false"
+          },
+          "totals": {
+            "FAIL": 1
+          }
+        }
+      }
+    },
+    "/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html": {
+      "byUA": {
+        "CD63": "OK",
+        "FA57": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "Receiving a message through PresentationConnection": {
+          "stNum": 0,
+          "byUA": {
+            "CD63": "PASS",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "FA57": "assert_equals: receive a string correctly expected \"1st\" but got \"1st2nd\""
+          },
+          "totals": {
+            "PASS": 1,
+            "FAIL": 1
+          }
+        }
+      }
+    },
+    "/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html": {
+      "byUA": {
+        "CD63": "OK",
+        "FA57": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "Sending a message through PresentationConnection": {
+          "stNum": 0,
+          "byUA": {
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CD63": "promise_test: Unhandled rejection with value: undefined",
+            "FA57": "assert_true: send a string correctly expected true got false"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        }
+      }
+    },
+    "/presentation-api/receiving-ua/PresentationConnection_terminate-manual.https.html": {
+      "byUA": {
+        "CD63": "OK",
+        "FA57": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "Terminating a presentation in a receiving browsing context": {
+          "stNum": 0,
+          "byUA": {
+            "CD63": "PASS",
+            "FA57": "TIMEOUT"
+          },
+          "UAmessage": {},
+          "totals": {
+            "PASS": 1,
+            "TIMEOUT": 1
+          }
+        }
+      }
+    },
+    "/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html": {
+      "byUA": {
+        "CD63": "OK",
+        "FA57": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 2
+      },
+      "subtests": {
+        "Creating a receiving browsing context": {
+          "stNum": 0,
+          "byUA": {
+            "CD63": "FAIL",
+            "FA57": "FAIL"
+          },
+          "UAmessage": {
+            "CD63": "promise_test: Unhandled rejection with value: \"A receiving user agent unexpectedly closed a presentation. \"",
+            "FA57": "assert_unreached: Top-level navigation is disabled. Reached unreachable code"
+          },
+          "totals": {
+            "FAIL": 2
+          }
+        }
+      }
+    },
+    "/presentation-api/receiving-ua/idlharness-manual.https.html": {
+      "byUA": {
+        "CD63": "OK",
+        "FA57": "OK"
+      },
+      "UAmessage": {},
+      "totals": {
+        "OK": 2
       },
       "subtests": {
         "Navigator interface: attribute presentation": {
+          "stNum": 0,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "Presentation interface: existence and properties of interface object": {
+          "stNum": 1,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "Presentation interface object length": {
+          "stNum": 2,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "Presentation interface object name": {
+          "stNum": 3,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "Presentation interface: existence and properties of interface prototype object": {
+          "stNum": 4,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "Presentation interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 5,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "Presentation interface: attribute receiver": {
+          "stNum": 6,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "Presentation must be primary interface of navigator.presentation": {
+          "stNum": 7,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "Stringification of navigator.presentation": {
+          "stNum": 8,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
-        "Presentation interface: navigator.presentation must inherit property \"receiver\" with the proper type (0)": {
+        "Presentation interface: navigator.presentation must inherit property \"receiver\" with the proper type": {
+          "stNum": 9,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionAvailableEvent interface: existence and properties of interface object": {
+          "stNum": 10,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionAvailableEvent interface object length": {
+          "stNum": 11,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionAvailableEvent interface object name": {
+          "stNum": 12,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object": {
+          "stNum": 13,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 14,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionAvailableEvent interface: attribute connection": {
+          "stNum": 15,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: existence and properties of interface object": {
+          "stNum": 16,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface object length": {
+          "stNum": 17,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface object name": {
+          "stNum": 18,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: existence and properties of interface prototype object": {
+          "stNum": 19,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 20,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: attribute id": {
+          "stNum": 21,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
+          }
+        },
+        "PresentationConnection interface: attribute url": {
+          "stNum": 22,
+          "byUA": {
+            "CD63": "PASS",
+            "FA57": "PASS"
+          },
+          "UAmessage": {},
+          "totals": {
+            "PASS": 2
           }
         },
         "PresentationConnection interface: attribute state": {
+          "stNum": 23,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: operation close()": {
+          "stNum": 24,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: operation terminate()": {
+          "stNum": 25,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 1,
             "PASS": 2
           }
         },
         "PresentationConnection interface: attribute onconnect": {
+          "stNum": 26,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "PresentationConnection interface: attribute onclose": {
+          "stNum": 27,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "PresentationConnection interface: attribute onterminate": {
+          "stNum": 28,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "PresentationConnection interface: attribute binaryType": {
+          "stNum": 29,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: attribute onmessage": {
+          "stNum": 30,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: operation send(DOMString)": {
+          "stNum": 31,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: operation send(Blob)": {
+          "stNum": 32,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: operation send(ArrayBuffer)": {
+          "stNum": 33,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
         "PresentationConnection interface: operation send(ArrayBufferView)": {
+          "stNum": 34,
           "byUA": {
-            "CC47": "PASS",
-            "CC49": "PASS",
-            "CD53": "PASS"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "PASS": 3
+            "PASS": 2
           }
         },
-        "PresentationConnectionClosedEvent interface: existence and properties of interface object": {
+        "PresentationConnectionCloseEvent interface: existence and properties of interface object": {
+          "stNum": 35,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
-        "PresentationConnectionClosedEvent interface object length": {
+        "PresentationConnectionCloseEvent interface object length": {
+          "stNum": 36,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
-        "PresentationConnectionClosedEvent interface object name": {
+        "PresentationConnectionCloseEvent interface object name": {
+          "stNum": 37,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
-        "PresentationConnectionClosedEvent interface: existence and properties of interface prototype object": {
+        "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object": {
+          "stNum": 38,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
-        "PresentationConnectionClosedEvent interface: existence and properties of interface prototype object's \"constructor\" property": {
+        "PresentationConnectionCloseEvent interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 39,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
-        "PresentationConnectionClosedEvent interface: attribute reason": {
+        "PresentationConnectionCloseEvent interface: attribute reason": {
+          "stNum": 40,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
-        "PresentationConnectionClosedEvent interface: attribute message": {
+        "PresentationConnectionCloseEvent interface: attribute message": {
+          "stNum": 41,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationReceiver interface: existence and properties of interface object": {
+          "stNum": 42,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationReceiver interface object length": {
+          "stNum": 43,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationReceiver interface object name": {
+          "stNum": 44,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationReceiver interface: existence and properties of interface prototype object": {
+          "stNum": 45,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationReceiver interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 46,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationReceiver interface: attribute connectionList": {
+          "stNum": 47,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationReceiver must be primary interface of navigator.presentation.receiver": {
+          "stNum": 48,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "Stringification of navigator.presentation.receiver": {
+          "stNum": 49,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
-        "PresentationReceiver interface: navigator.presentation.receiver must inherit property \"connectionList\" with the proper type (0)": {
+        "PresentationReceiver interface: navigator.presentation.receiver must inherit property \"connectionList\" with the proper type": {
+          "stNum": 50,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionList interface: existence and properties of interface object": {
+          "stNum": 51,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionList interface object length": {
+          "stNum": 52,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionList interface object name": {
+          "stNum": 53,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionList interface: existence and properties of interface prototype object": {
+          "stNum": 54,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionList interface: existence and properties of interface prototype object's \"constructor\" property": {
+          "stNum": 55,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionList interface: attribute connections": {
+          "stNum": 56,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         },
         "PresentationConnectionList interface: attribute onconnectionavailable": {
+          "stNum": 57,
           "byUA": {
-            "CC47": "FAIL",
-            "CC49": "FAIL",
-            "CD53": "FAIL"
+            "CD63": "PASS",
+            "FA57": "PASS"
           },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }

--- a/presentation-api/receiving-ua/less-than-2.html
+++ b/presentation-api/receiving-ua/less-than-2.html
@@ -11,48 +11,37 @@
       <header>
         <h1>Presentation API - Receiving UA: Less Than 2 Passes</h1>
       </header>
-      <p><strong>Test files without 2 passes</strong>: 1; <strong>Subtests without 2 passes: </strong>31; <strong>Failure level</strong>: 31/57 (54.39%)</p>
+      
+      <p><strong>Test files without 2 passes</strong>: 6; <strong>Subtests without 2 passes: </strong>6; <strong>Failure level</strong>: 6/64 (9.38%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/presentation-api/receiving-ua/idlharness.html</a> <small>(31/57, 54.39%, 54.39% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
+<li><a href='#test-file-1'>/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
+<li><a href='#test-file-2'>/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
+<li><a href='#test-file-3'>/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
+<li><a href='#test-file-4'>/presentation-api/receiving-ua/PresentationConnection_terminate-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
+<li><a href='#test-file-5'>/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test</th><th>CC47</th><th>CC49</th><th>CD53</th></tr></thead>
-<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/idlharness.html' target='_blank'>/presentation-api/receiving-ua/idlharness.html</a> <small>(31/57, 54.39%, 54.39% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr class='subtest'><td>Presentation interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Presentation interface: attribute receiver</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Presentation interface: navigator.presentation must inherit property "receiver" with the proper type (0)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionAvailableEvent interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onconnect</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onclose</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnection interface: attribute onterminate</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: existence and properties of interface object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface object name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: existence and properties of interface prototype object's "constructor" property</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: attribute reason</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionClosedEvent interface: attribute message</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface object name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: existence and properties of interface prototype object's "constructor" property</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: attribute connectionList</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver must be primary interface of navigator.presentation.receiver</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>Stringification of navigator.presentation.receiver</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationReceiver interface: navigator.presentation.receiver must inherit property "connectionList" with the proper type (0)</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface object length</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface object name</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface prototype object</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: existence and properties of interface prototype object's "constructor" property</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: attribute connections</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='subtest'><td>PresentationConnectionList interface: attribute onconnectionavailable</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>CD63</th><th>FA57</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnectionList_onconnectionavailable-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-0-0' class='subtest'><td>Monitoring incoming presentation connections</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_onclose-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-1-0' class='subtest'><td>Closing a PresentationConnection</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-2-0' class='subtest'><td>Receiving a message through PresentationConnection</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-3-0' class='subtest'><td>Sending a message through PresentationConnection</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationConnection_terminate-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationConnection_terminate-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-4-0' class='subtest'><td>Terminating a presentation in a receiving browsing context</td><td class='PASS'>PASS</td><td class='TIMEOUT'>TIMEOUT</td></tr>
+<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html' target='_blank'>/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html</a> <small>(1/1, 100.00%, 1.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-5-0' class='subtest'><td>Creating a receiving browsing context</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
+    <script type='application/javascript'>
+      
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This PR updates Presentation API test results from both controlling and receiving UAs, #107 and #111. The following browsers are considered:

- CD63: Chrome Canary for Desktop Version 63.x.x
- CA63: Chrome Canary for Android Version 63.x.x (only for controlling UA tests)
- FA57: Firefox Nightly for Android Version 57.x

Note that:

- These tests are done with a local server (`./wpt serve`), so that wptserver's Stash could work more stable.
- On Chrome for Desktop, starting a presentation sometimes fails after presentations are started and terminated for several times, which might make test automation difficult. As far as I have tried, this can be avoided by starting mirroring manually before using Presentation API.
- On Chrome Canary for Desktop, two unknown devices named "test-sink-1" and "test-sink-2" appear on the selection dialog even when no presentation display is available.
- On Firefox Nightly, controlling UA's screen becomes broken when a presentation starts.