### PR TITLE
Core-AAM: Updated results for macOS and Linux

### DIFF
--- a/core-aam/FF01.json
+++ b/core-aam/FF01.json
@@ -899,7 +899,7 @@
         {
           "name": "aria-modal=false NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -916,7 +916,7 @@
         {
           "name": "aria-modal=true NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",

--- a/core-aam/FF02.json
+++ b/core-aam/FF02.json
@@ -59,7 +59,7 @@
         {
           "name": "aria-atomic=true 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -212,7 +212,7 @@
         {
           "name": "aria-colcount NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -253,7 +253,7 @@
         {
           "name": "aria-controls 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -300,7 +300,7 @@
         {
           "name": "aria-describedby 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -335,7 +335,7 @@
         {
           "name": "aria-disabled=true 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -430,7 +430,7 @@
         {
           "name": "aria-errormessage 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -488,7 +488,7 @@
         {
           "name": "aria-flowto 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -737,7 +737,7 @@
         {
           "name": "aria-labelledby 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -778,7 +778,7 @@
         {
           "name": "aria-live=assertive 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -795,7 +795,7 @@
         {
           "name": "aria-live=off 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -812,7 +812,7 @@
         {
           "name": "aria-live=polite 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -923,7 +923,7 @@
         {
           "name": "aria-owns may need manual verification 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         },
         {
           "name": "aria-owns may need manual verification 2",
@@ -1047,7 +1047,7 @@
         {
           "name": "aria-readonly=true on radiogroup 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1082,7 +1082,7 @@
         {
           "name": "aria-relevant 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1141,7 +1141,7 @@
         {
           "name": "aria-rowcount NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1158,7 +1158,7 @@
         {
           "name": "aria-rowindex NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",

--- a/core-aam/GC02.json
+++ b/core-aam/GC02.json
@@ -59,7 +59,7 @@
         {
           "name": "aria-atomic=true 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -212,7 +212,7 @@
         {
           "name": "aria-colcount NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -253,7 +253,7 @@
         {
           "name": "aria-controls 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -300,7 +300,7 @@
         {
           "name": "aria-describedby 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -335,7 +335,7 @@
         {
           "name": "aria-disabled=true 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -430,7 +430,7 @@
         {
           "name": "aria-errormessage 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -488,7 +488,7 @@
         {
           "name": "aria-flowto 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -737,7 +737,7 @@
         {
           "name": "aria-labelledby 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -778,7 +778,7 @@
         {
           "name": "aria-live=assertive 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -795,7 +795,7 @@
         {
           "name": "aria-live=off 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -812,7 +812,7 @@
         {
           "name": "aria-live=polite 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -923,7 +923,7 @@
         {
           "name": "aria-owns may need manual verification 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         },
         {
           "name": "aria-owns may need manual verification 2",
@@ -1047,7 +1047,7 @@
         {
           "name": "aria-readonly=true on radiogroup 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1082,7 +1082,7 @@
         {
           "name": "aria-relevant 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1141,7 +1141,7 @@
         {
           "name": "aria-rowcount NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1158,7 +1158,7 @@
         {
           "name": "aria-rowindex NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",

--- a/core-aam/WK01.json
+++ b/core-aam/WK01.json
@@ -899,7 +899,7 @@
         {
           "name": "aria-modal=false NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",
@@ -916,7 +916,7 @@
         {
           "name": "aria-modal=true NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API ATK expected false got true"
         }
       ],
       "status": "OK",

--- a/core-aam/WK02.json
+++ b/core-aam/WK02.json
@@ -59,7 +59,7 @@
         {
           "name": "aria-atomic=true 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -212,7 +212,7 @@
         {
           "name": "aria-colcount NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -253,7 +253,7 @@
         {
           "name": "aria-controls 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -300,7 +300,7 @@
         {
           "name": "aria-describedby 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -335,7 +335,7 @@
         {
           "name": "aria-disabled=true 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -430,7 +430,7 @@
         {
           "name": "aria-errormessage 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -488,7 +488,7 @@
         {
           "name": "aria-flowto 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -737,7 +737,7 @@
         {
           "name": "aria-labelledby 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -778,7 +778,7 @@
         {
           "name": "aria-live=assertive 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -795,7 +795,7 @@
         {
           "name": "aria-live=off 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -812,7 +812,7 @@
         {
           "name": "aria-live=polite 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -923,7 +923,7 @@
         {
           "name": "aria-owns may need manual verification 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         },
         {
           "name": "aria-owns may need manual verification 2",
@@ -1047,7 +1047,7 @@
         {
           "name": "aria-readonly=true on radiogroup 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1082,7 +1082,7 @@
         {
           "name": "aria-relevant 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1141,7 +1141,7 @@
         {
           "name": "aria-rowcount NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",
@@ -1158,7 +1158,7 @@
         {
           "name": "aria-rowindex NEW 1",
           "status": "FAIL",
-          "message": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+          "message": "assert_false: NOTRUN: No assertion for API AXAPI expected false got true"
         }
       ],
       "status": "OK",

--- a/core-aam/all.html
+++ b/core-aam/all.html
@@ -12,7 +12,7 @@
         <h1>Core AAM 1.1: All Results</h1>
       </header>
       
-      <p><strong>Test files</strong>: 220; <strong>Total subtests</strong>: 249</p>
+      <p><strong>Test files</strong>: 220; <strong>Total subtests</strong>: 245</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/core-aam/alert-manual.html</a></li>
 <li><a href='#test-file-1'>/core-aam/alertdialog-manual.html</a></li>
@@ -275,13 +275,10 @@
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-4-1' class='subtest'><td>aria-atomic=true 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "relation RELATION</em>MEMBER_OF is [test]" failed <br />
+<tr id='subtest-4-1' class='subtest'><td>aria-atomic=true 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "relation RELATION</em>MEMBER_OF is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/core-aam/aria-autocomplete_both-manual.html' target='_blank'>/core-aam/aria-autocomplete_both-manual.html</a></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-5-0' class='subtest'><td>aria-autocomplete=both</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
@@ -373,11 +370,6 @@
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-17-1' class='subtest'><td>aria-colcount NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
 <tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/core-aam/aria-colindex_new-manual.html' target='_blank'>/core-aam/aria-colindex_new-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-18-0' class='subtest'><td>aria-colindex NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "result atk</em>table<em>cell</em>get_position() contains column=2" failed <br />
@@ -417,11 +409,7 @@
 <strong>Actual value:</strong> [] <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-20-1' class='subtest'><td>aria-controls 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-20-1' class='subtest'><td>aria-controls 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/core-aam/aria-current_value_changes-manual.html' target='_blank'>/core-aam/aria-current_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-21-0' class='subtest'><td>aria-current value changes</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr id='subtest-21-1' class='subtest'><td>aria-current value changes 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
@@ -448,11 +436,7 @@
 </table></td></tr>
 <tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/core-aam/aria-describedby-manual.html' target='_blank'>/core-aam/aria-describedby-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-24-0' class='subtest'><td>aria-describedby</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-24-1' class='subtest'><td>aria-describedby 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-24-1' class='subtest'><td>aria-describedby 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/core-aam/aria-details_new-manual.html' target='_blank'>/core-aam/aria-details_new-manual.html</a></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-25-0' class='subtest'><td>aria-details NEW</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr id='subtest-25-1' class='subtest'><td>aria-details NEW 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
@@ -460,11 +444,6 @@
 <tr id='subtest-26-0' class='subtest'><td>aria-disabled=false</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/core-aam/aria-disabled_true-manual.html' target='_blank'>/core-aam/aria-disabled_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-27-0' class='subtest'><td>aria-disabled=true</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-27-1' class='subtest'><td>aria-disabled=true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
 <tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/core-aam/aria-disabled_value_changes-manual.html' target='_blank'>/core-aam/aria-disabled_value_changes-manual.html</a></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-28-0' class='subtest'><td>aria-disabled value changes</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:enabled" failed <br />
@@ -556,11 +535,7 @@
 <a href="https://webkit.org/b/165190">https://webkit.org/b/165190</a>: [NEW] AX: Implement aria-errormesage <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-36-1' class='subtest'><td>aria-errormessage 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-36-1' class='subtest'><td>aria-errormessage 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/core-aam/aria-expanded_false-manual.html' target='_blank'>/core-aam/aria-expanded_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-37-0' class='subtest'><td>aria-expanded=false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXExpanded is NO" failed <br />
@@ -600,11 +575,7 @@
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-40-1' class='subtest'><td>aria-flowto 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-40-1' class='subtest'><td>aria-flowto 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/core-aam/aria-grabbed_false-manual.html' target='_blank'>/core-aam/aria-grabbed_false-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-41-0' class='subtest'><td>aria-grabbed=false</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXGrabbed is NO" failed <br />
@@ -780,11 +751,7 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-61-1' class='subtest'><td>aria-labelledby 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-61-1' class='subtest'><td>aria-labelledby 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-62'><td><a href='http://www.w3c-test.org/core-aam/aria-level_on_heading-manual.html' target='_blank'>/core-aam/aria-level_on_heading-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-62-0' class='subtest'><td>aria-level on heading</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXValue is 2" failed <br />
@@ -806,11 +773,7 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-64-1' class='subtest'><td>aria-live=assertive 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-64-1' class='subtest'><td>aria-live=assertive 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-65'><td><a href='http://www.w3c-test.org/core-aam/aria-live_off-manual.html' target='_blank'>/core-aam/aria-live_off-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-65-0' class='subtest'><td>aria-live=off</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIALive is off" failed <br />
@@ -820,39 +783,26 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-65-1' class='subtest'><td>aria-live=off 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-65-1' class='subtest'><td>aria-live=off 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-66'><td><a href='http://www.w3c-test.org/core-aam/aria-live_polite-manual.html' target='_blank'>/core-aam/aria-live_polite-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-66-0' class='subtest'><td>aria-live=polite</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXARIALive is polite" failed <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-66-1' class='subtest'><td>aria-live=polite 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-66-1' class='subtest'><td>aria-live=polite 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-67'><td><a href='http://www.w3c-test.org/core-aam/aria-modal_false_new-manual.html' target='_blank'>/core-aam/aria-modal_false_new-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-67-0' class='subtest'><td>aria-modal=false NEW</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-67-1' class='subtest'><td>aria-modal=false NEW 1</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-67-1' class='subtest'><td>aria-modal=false NEW 1</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-68'><td><a href='http://www.w3c-test.org/core-aam/aria-modal_true_new-manual.html' target='_blank'>/core-aam/aria-modal_true_new-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-68-0' class='subtest'><td>aria-modal=true NEW</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-68-1' class='subtest'><td>aria-modal=true NEW 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property accessible is false" failed <br />
+<tr id='subtest-68-1' class='subtest'><td>aria-modal=true NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-69'><td><a href='http://www.w3c-test.org/core-aam/aria-multiline_false-manual.html' target='_blank'>/core-aam/aria-multiline_false-manual.html</a></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-69-0' class='subtest'><td>aria-multiline=false</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
@@ -895,13 +845,10 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-76-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-76-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
 <tr id='subtest-76-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed <br />
@@ -987,17 +934,14 @@ ERROR: Object not found <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-86-1' class='subtest'><td>aria-readonly=true on radiogroup 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr id='subtest-86-1' class='subtest'><td>aria-readonly=true on radiogroup 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property states doesNotContain STATE</em>CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "property states doesNotContain STATE</em>CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SELECTABLE', 'STATE_SENSITIVE', 'STATE_CHECKABLE'] <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-87'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_true_on_textbox-manual.html' target='_blank'>/core-aam/aria-readonly_true_on_textbox-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-87-0' class='subtest'><td>aria-readonly=true on textbox</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
@@ -1031,11 +975,7 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-89-1' class='subtest'><td>aria-relevant 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
+<tr id='subtest-89-1' class='subtest'><td>aria-relevant 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-90'><td><a href='http://www.w3c-test.org/core-aam/aria-required_true-manual.html' target='_blank'>/core-aam/aria-required_true-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-90-0' class='subtest'><td>aria-required=true</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXRequired is YES" failed <br />
@@ -1076,11 +1016,6 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> None <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-94-1' class='subtest'><td>aria-rowcount NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
 <tr class='test' id='test-file-95'><td><a href='http://www.w3c-test.org/core-aam/aria-rowindex_new-manual.html' target='_blank'>/core-aam/aria-rowindex_new-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-95-0' class='subtest'><td>aria-rowindex NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "result atk</em>table<em>cell</em>get_position() contains row=2" failed <br />
@@ -1097,11 +1032,6 @@ ERROR: Object not found <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
-</table></td></tr>
-<tr id='subtest-95-1' class='subtest'><td>aria-rowindex NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-96'><td><a href='http://www.w3c-test.org/core-aam/aria-rowspan_new-manual.html' target='_blank'>/core-aam/aria-rowspan_new-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-96-0' class='subtest'><td>aria-rowspan NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>

--- a/core-aam/complete-fails.html
+++ b/core-aam/complete-fails.html
@@ -12,53 +12,37 @@
         <h1>Core AAM 1.1: Complete Failures</h1>
       </header>
       
-      <p><strong>Completely failed files</strong>: 27; <strong>Completely failed subtests</strong>: 15; <strong>Failure level</strong>: 15/249 (6.02%)</p>
+      <p><strong>Completely failed files</strong>: 24; <strong>Completely failed subtests</strong>: 11; <strong>Failure level</strong>: 11/245 (4.49%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/core-aam/aria-colcount_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-1'>/core-aam/aria-disabled_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-2'>/core-aam/aria-dropeffect_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-3'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-4'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-5'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></li>
-<li><a href='#test-file-6'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-7'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></li>
-<li><a href='#test-file-8'>/core-aam/aria-rowcount_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-9'>/core-aam/aria-rowindex_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-10'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-11'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-12'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/core-aam/aria-dropeffect_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-1'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-2'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-3'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></li>
+<li><a href='#test-file-4'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(1/2, 50.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-5'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></li>
+<li><a href='#test-file-6'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-7'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-8'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>FF02</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
-<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/core-aam/aria-colcount_new-manual.html' target='_blank'>/core-aam/aria-colcount_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-17-1' class='subtest'><td>aria-colcount NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/core-aam/aria-disabled_true-manual.html' target='_blank'>/core-aam/aria-disabled_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-27-1' class='subtest'><td>aria-disabled=true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/core-aam/aria-dropeffect_value_changes-manual.html' target='_blank'>/core-aam/aria-dropeffect_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/core-aam/aria-dropeffect_value_changes-manual.html' target='_blank'>/core-aam/aria-dropeffect_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-35-0' class='subtest'><td>aria-dropeffect value changes</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/core-aam/aria-grabbed_value_changes-manual.html' target='_blank'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/core-aam/aria-grabbed_value_changes-manual.html' target='_blank'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-43-0' class='subtest'><td>aria-grabbed value changes</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/core-aam/aria-haspopup_false-manual.html' target='_blank'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/core-aam/aria-haspopup_false-manual.html' target='_blank'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-45-0' class='subtest'><td>/core-aam/aria-haspopup_false-manual.html</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td></tr>
-<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/core-aam/aria-hidden_value_changes-manual.html' target='_blank'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/core-aam/aria-hidden_value_changes-manual.html' target='_blank'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-52-0' class='subtest'><td>aria-hidden value changes</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
@@ -83,20 +67,17 @@
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXUIElementCreated" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_true_on_radiogroup-manual.html' target='_blank'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-86-1' class='subtest'><td>aria-readonly=true on radiogroup 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_true_on_radiogroup-manual.html' target='_blank'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(1/2, 50.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-86-1' class='subtest'><td>aria-readonly=true on radiogroup 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property states doesNotContain STATE</em>CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "property states doesNotContain STATE</em>CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SELECTABLE', 'STATE_SENSITIVE', 'STATE_CHECKABLE'] <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-88'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_value_changes-manual.html' target='_blank'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-88'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_value_changes-manual.html' target='_blank'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-88-0' class='subtest'><td>aria-readonly value changes</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:state-changed:read-only" failed <br />
 ;  expected true got false</td></tr>
@@ -109,19 +90,7 @@
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:read-only" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-94'><td><a href='http://www.w3c-test.org/core-aam/aria-rowcount_new-manual.html' target='_blank'>/core-aam/aria-rowcount_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-94-1' class='subtest'><td>aria-rowcount NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-95'><td><a href='http://www.w3c-test.org/core-aam/aria-rowindex_new-manual.html' target='_blank'>/core-aam/aria-rowindex_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-95-1' class='subtest'><td>aria-rowindex NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-133'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_math-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-133'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_math-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-133-0' class='subtest'><td>Exclude presentational children of math</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
@@ -139,7 +108,7 @@
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-134'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-134'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-134-0' class='subtest'><td>Exclude presentational children of menuitemcheckbox NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
@@ -157,7 +126,7 @@
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-135-0' class='subtest'><td>Exclude presentational children of menuitemradio NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />

--- a/core-aam/consolidated.json
+++ b/core-aam/consolidated.json
@@ -168,20 +168,14 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "FAIL",
-            "WK02": "FAIL"
+            "WK01": "FAIL"
           },
           "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK01": "assert_true: \"relation RELATION_MEMBER_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+            "WK01": "assert_true: \"relation RELATION_MEMBER_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
           },
           "totals": {
             "PASS": 1,
-            "FAIL": 4
+            "FAIL": 1
           }
         }
       }
@@ -634,22 +628,6 @@
             "FAIL": 3,
             "PASS": 2
           }
-        },
-        "aria-colcount NEW 1": {
-          "stNum": 1,
-          "byUA": {
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK02": "FAIL"
-          },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
-          "totals": {
-            "FAIL": 3
-          }
         }
       }
     },
@@ -757,19 +735,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -914,19 +884,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -1027,22 +989,6 @@
           "UAmessage": {},
           "totals": {
             "PASS": 5
-          }
-        },
-        "aria-disabled=true 1": {
-          "stNum": 1,
-          "byUA": {
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK02": "FAIL"
-          },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
-          "totals": {
-            "FAIL": 3
           }
         }
       }
@@ -1355,19 +1301,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -1525,19 +1463,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -2271,19 +2201,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -2387,19 +2309,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -2439,19 +2353,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -2490,19 +2396,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -2534,18 +2432,12 @@
         "aria-modal=false NEW 1": {
           "stNum": 1,
           "byUA": {
-            "FF01": "FAIL",
             "FF02": "PASS",
             "GC02": "PASS",
-            "WK01": "FAIL",
             "WK02": "PASS"
           },
-          "UAmessage": {
-            "FF01": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK01": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
             "PASS": 3
           }
         }
@@ -2578,20 +2470,16 @@
         "aria-modal=true NEW 1": {
           "stNum": 1,
           "byUA": {
-            "FF01": "FAIL",
             "FF02": "FAIL",
             "GC02": "FAIL",
-            "WK01": "FAIL",
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
             "FF02": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false",
-            "GC02": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false",
-            "WK01": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+            "GC02": "assert_true: \"property accessible is false\" failed   \n**Actual value:** true  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4,
+            "FAIL": 2,
             "PASS": 1
           }
         }
@@ -2852,19 +2740,13 @@
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"relation RELATION_NODE_CHILD_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false",
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+            "FF01": "assert_true: \"relation RELATION_NODE_CHILD_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 4,
+            "FAIL": 1,
             "PASS": 1
           }
         },
@@ -3225,20 +3107,14 @@
           "stNum": 1,
           "byUA": {
             "FF01": "FAIL",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "FAIL",
-            "WK02": "FAIL"
+            "WK01": "FAIL"
           },
           "UAmessage": {
             "FF01": "assert_true: \"property states doesNotContain STATE_CHECKABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_OPAQUE', 'STATE\\_SENSITIVE', 'STATE\\_SHOWING', 'STATE\\_VISIBLE', 'STATE\\_SELECTABLE\\_TEXT', 'STATE\\_CHECKABLE']  \n<https://bugzil.la/1356018>: [NEW] Elements with aria-readonly=\"true\" should expose ATK\\_STATE\\_READ\\_ONLY  \n;  expected true got false",
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK01": "assert_true: \"property states doesNotContain STATE_CHECKABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_HORIZONTAL', 'STATE\\_SELECTABLE', 'STATE\\_SENSITIVE', 'STATE\\_CHECKABLE']  \n;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
+            "WK01": "assert_true: \"property states doesNotContain STATE_CHECKABLE\" failed   \n**Actual value:** ['STATE\\_ENABLED', 'STATE\\_HORIZONTAL', 'STATE\\_SELECTABLE', 'STATE\\_SENSITIVE', 'STATE\\_CHECKABLE']  \n;  expected true got false"
           },
           "totals": {
-            "FAIL": 5
+            "FAIL": 2
           }
         }
       }
@@ -3359,19 +3235,11 @@
           "stNum": 1,
           "byUA": {
             "FF01": "PASS",
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK01": "PASS",
-            "WK02": "FAIL"
+            "WK01": "PASS"
           },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
+          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 3
+            "PASS": 2
           }
         }
       }
@@ -3553,22 +3421,6 @@
             "FAIL": 3,
             "PASS": 2
           }
-        },
-        "aria-rowcount NEW 1": {
-          "stNum": 1,
-          "byUA": {
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK02": "FAIL"
-          },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
-          "totals": {
-            "FAIL": 3
-          }
         }
       }
     },
@@ -3603,22 +3455,6 @@
           "totals": {
             "FAIL": 4,
             "PASS": 1
-          }
-        },
-        "aria-rowindex NEW 1": {
-          "stNum": 1,
-          "byUA": {
-            "FF02": "FAIL",
-            "GC02": "FAIL",
-            "WK02": "FAIL"
-          },
-          "UAmessage": {
-            "FF02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "GC02": "assert_true: ERROR: No results reported from ATTA;  expected true got false",
-            "WK02": "assert_true: ERROR: No results reported from ATTA;  expected true got false"
-          },
-          "totals": {
-            "FAIL": 3
           }
         }
       }

--- a/core-aam/less-than-2.html
+++ b/core-aam/less-than-2.html
@@ -12,54 +12,42 @@
         <h1>Core AAM 1.1: Less Than 2 Passes</h1>
       </header>
       
-      <p><strong>Test files without 2 passes</strong>: 27; <strong>Subtests without 2 passes: </strong>34; <strong>Failure level</strong>: 34/249 (13.65%)</p>
+      <p><strong>Test files without 2 passes</strong>: 24; <strong>Subtests without 2 passes: </strong>30; <strong>Failure level</strong>: 30/245 (12.24%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/core-aam/aria-atomic_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-1'>/core-aam/aria-colcount_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-2'>/core-aam/aria-colindex_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-3'>/core-aam/aria-disabled_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-4'>/core-aam/aria-disabled_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-5'>/core-aam/aria-dropeffect_none-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-6'>/core-aam/aria-dropeffect_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-7'>/core-aam/aria-expanded_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></li>
-<li><a href='#test-file-8'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-9'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-10'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></li>
-<li><a href='#test-file-11'>/core-aam/aria-keyshortcuts_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-12'>/core-aam/aria-modal_true_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-13'>/core-aam/aria-multiselectable_false-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-14'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(2/3, 66.67%, 0.80% of total)</small></li>
-<li><a href='#test-file-15'>/core-aam/aria-pressed_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></li>
-<li><a href='#test-file-16'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-17'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></li>
-<li><a href='#test-file-18'>/core-aam/aria-required_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></li>
-<li><a href='#test-file-19'>/core-aam/aria-rowcount_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-20'>/core-aam/aria-rowindex_new-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></li>
-<li><a href='#test-file-21'>/core-aam/aria-sort_none-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-22'>/core-aam/aria-valuetext_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-23'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-24'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-25'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
-<li><a href='#test-file-26'>/core-aam/exclude_presentational_children_of_separator-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/core-aam/aria-atomic_true-manual.html</a> <small>(1/2, 50.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-1'>/core-aam/aria-colindex_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-2'>/core-aam/aria-disabled_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-3'>/core-aam/aria-dropeffect_none-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-4'>/core-aam/aria-dropeffect_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-5'>/core-aam/aria-expanded_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></li>
+<li><a href='#test-file-6'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-7'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-8'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></li>
+<li><a href='#test-file-9'>/core-aam/aria-keyshortcuts_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-10'>/core-aam/aria-modal_true_new-manual.html</a> <small>(1/2, 50.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-11'>/core-aam/aria-multiselectable_false-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-12'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(2/3, 66.67%, 0.82% of total)</small></li>
+<li><a href='#test-file-13'>/core-aam/aria-pressed_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></li>
+<li><a href='#test-file-14'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(1/2, 50.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-15'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></li>
+<li><a href='#test-file-16'>/core-aam/aria-required_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></li>
+<li><a href='#test-file-17'>/core-aam/aria-rowindex_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-18'>/core-aam/aria-sort_none-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-19'>/core-aam/aria-valuetext_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-20'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-21'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-22'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
+<li><a href='#test-file-23'>/core-aam/exclude_presentational_children_of_separator-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>FF02</th><th>GC02</th><th>WK01</th><th>WK02</th></tr></thead>
-<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/core-aam/aria-atomic_true-manual.html' target='_blank'>/core-aam/aria-atomic_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-4-1' class='subtest'><td>aria-atomic=true 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "relation RELATION</em>MEMBER_OF is [test]" failed <br />
+<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/core-aam/aria-atomic_true-manual.html' target='_blank'>/core-aam/aria-atomic_true-manual.html</a> <small>(1/2, 50.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-4-1' class='subtest'><td>aria-atomic=true 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "relation RELATION</em>MEMBER_OF is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/core-aam/aria-colcount_new-manual.html' target='_blank'>/core-aam/aria-colcount_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-17-1' class='subtest'><td>aria-colcount NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/core-aam/aria-colindex_new-manual.html' target='_blank'>/core-aam/aria-colindex_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/core-aam/aria-colindex_new-manual.html' target='_blank'>/core-aam/aria-colindex_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-18-0' class='subtest'><td>aria-colindex NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "result atk</em>table<em>cell</em>get_position() contains column=2" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
@@ -76,31 +64,25 @@
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/core-aam/aria-disabled_true-manual.html' target='_blank'>/core-aam/aria-disabled_true-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-27-1' class='subtest'><td>aria-disabled=true 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/core-aam/aria-disabled_value_changes-manual.html' target='_blank'>/core-aam/aria-disabled_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/core-aam/aria-disabled_value_changes-manual.html' target='_blank'>/core-aam/aria-disabled_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-28-0' class='subtest'><td>aria-disabled value changes</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:enabled" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/core-aam/aria-dropeffect_none-manual.html' target='_blank'>/core-aam/aria-dropeffect_none-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/core-aam/aria-dropeffect_none-manual.html' target='_blank'>/core-aam/aria-dropeffect_none-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-33-0' class='subtest'><td>aria-dropeffect=none</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains dropeffect:none" failed <br />
 <strong>Actual value:</strong> ['computed-role:group', 'xml-roles:group', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk'] <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/core-aam/aria-dropeffect_value_changes-manual.html' target='_blank'>/core-aam/aria-dropeffect_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/core-aam/aria-dropeffect_value_changes-manual.html' target='_blank'>/core-aam/aria-dropeffect_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-35-0' class='subtest'><td>aria-dropeffect value changes</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-39'><td><a href='http://www.w3c-test.org/core-aam/aria-expanded_value_changes-manual.html' target='_blank'>/core-aam/aria-expanded_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-39'><td><a href='http://www.w3c-test.org/core-aam/aria-expanded_value_changes-manual.html' target='_blank'>/core-aam/aria-expanded_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-39-0' class='subtest'><td>aria-expanded value changes</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "event type is AXRowExpanded" failed <br />
 ;  expected true got false</td></tr>
@@ -121,16 +103,16 @@
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXRowCollapsed" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/core-aam/aria-grabbed_value_changes-manual.html' target='_blank'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/core-aam/aria-grabbed_value_changes-manual.html' target='_blank'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-43-0' class='subtest'><td>aria-grabbed value changes</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/core-aam/aria-haspopup_false-manual.html' target='_blank'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/core-aam/aria-haspopup_false-manual.html' target='_blank'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-45-0' class='subtest'><td>/core-aam/aria-haspopup_false-manual.html</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td></tr>
-<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/core-aam/aria-hidden_value_changes-manual.html' target='_blank'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/core-aam/aria-hidden_value_changes-manual.html' target='_blank'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-52-0' class='subtest'><td>aria-hidden value changes</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:property-change" failed <br />
 ;  expected true got false</td></tr>
@@ -155,45 +137,40 @@
 <tr class='message'><td class='ua'>WK02:</td><td> assert_true: "event type is AXUIElementCreated" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/core-aam/aria-keyshortcuts_new-manual.html' target='_blank'>/core-aam/aria-keyshortcuts_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-59'><td><a href='http://www.w3c-test.org/core-aam/aria-keyshortcuts_new-manual.html' target='_blank'>/core-aam/aria-keyshortcuts_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-59-0' class='subtest'><td>aria-keyshortcuts NEW</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains keyshortcuts:Shift+Space" failed <br />
 <strong>Actual value:</strong> ['computed-role:group', 'xml-roles:group', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk'] <br />
 <a href="https://webkit.org/b/171175">https://webkit.org/b/171175</a>: [NEW] [ATK] Expose value of aria-keyshortcuts as object attribute <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-68'><td><a href='http://www.w3c-test.org/core-aam/aria-modal_true_new-manual.html' target='_blank'>/core-aam/aria-modal_true_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-68-1' class='subtest'><td>aria-modal=true NEW 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property accessible is false" failed <br />
+<tr class='test' id='test-file-68'><td><a href='http://www.w3c-test.org/core-aam/aria-modal_true_new-manual.html' target='_blank'>/core-aam/aria-modal_true_new-manual.html</a> <small>(1/2, 50.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-68-1' class='subtest'><td>aria-modal=true NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK01:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-71'><td><a href='http://www.w3c-test.org/core-aam/aria-multiselectable_false-manual.html' target='_blank'>/core-aam/aria-multiselectable_false-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-71'><td><a href='http://www.w3c-test.org/core-aam/aria-multiselectable_false-manual.html' target='_blank'>/core-aam/aria-multiselectable_false-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-71-0' class='subtest'><td>aria-multiselectable=false</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "property states doesNotContain STATE</em>MULTISELECTABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_MULTISELECTABLE', 'STATE_SENSITIVE'] <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-76'><td><a href='http://www.w3c-test.org/core-aam/aria-owns_may_need_manual_verification-manual.html' target='_blank'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(2/3, 66.67%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-76-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-76'><td><a href='http://www.w3c-test.org/core-aam/aria-owns_may_need_manual_verification-manual.html' target='_blank'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(2/3, 66.67%, 0.82% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-76-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
 <tr id='subtest-76-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed <br />
 <strong>Actual value:</strong> [] <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-82'><td><a href='http://www.w3c-test.org/core-aam/aria-pressed_value_changes-manual.html' target='_blank'>/core-aam/aria-pressed_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-82'><td><a href='http://www.w3c-test.org/core-aam/aria-pressed_value_changes-manual.html' target='_blank'>/core-aam/aria-pressed_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-82-0' class='subtest'><td>aria-pressed value changes</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:pressed" failed <br />
 ;  expected true got false</td></tr>
@@ -202,20 +179,17 @@
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:pressed" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_true_on_radiogroup-manual.html' target='_blank'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-86-1' class='subtest'><td>aria-readonly=true on radiogroup 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-86'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_true_on_radiogroup-manual.html' target='_blank'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(1/2, 50.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr id='subtest-86-1' class='subtest'><td>aria-readonly=true on radiogroup 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property states doesNotContain STATE</em>CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT', 'STATE_CHECKABLE'] <br />
 <a href="https://bugzil.la/1356018">https://bugzil.la/1356018</a>: [NEW] Elements with aria-readonly="true" should expose ATK_STATE_READ_ONLY <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>WK01:</td><td> assert<em>true: "property states doesNotContain STATE</em>CHECKABLE" failed <br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_HORIZONTAL', 'STATE_SELECTABLE', 'STATE_SENSITIVE', 'STATE_CHECKABLE'] <br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-88'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_value_changes-manual.html' target='_blank'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-88'><td><a href='http://www.w3c-test.org/core-aam/aria-readonly_value_changes-manual.html' target='_blank'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-88-0' class='subtest'><td>aria-readonly value changes</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:state-changed:read-only" failed <br />
 ;  expected true got false</td></tr>
@@ -228,7 +202,7 @@
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:read-only" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-91'><td><a href='http://www.w3c-test.org/core-aam/aria-required_value_changes-manual.html' target='_blank'>/core-aam/aria-required_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-91'><td><a href='http://www.w3c-test.org/core-aam/aria-required_value_changes-manual.html' target='_blank'>/core-aam/aria-required_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.82% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-91-0' class='subtest'><td>aria-required value changes</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:required" failed <br />
 ;  expected true got false</td></tr>
@@ -237,13 +211,7 @@
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:state-changed:required" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-94'><td><a href='http://www.w3c-test.org/core-aam/aria-rowcount_new-manual.html' target='_blank'>/core-aam/aria-rowcount_new-manual.html</a> <small>(1/2, 50.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-94-1' class='subtest'><td>aria-rowcount NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-95'><td><a href='http://www.w3c-test.org/core-aam/aria-rowindex_new-manual.html' target='_blank'>/core-aam/aria-rowindex_new-manual.html</a> <small>(2/2, 100.00%, 0.80% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-95'><td><a href='http://www.w3c-test.org/core-aam/aria-rowindex_new-manual.html' target='_blank'>/core-aam/aria-rowindex_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-95-0' class='subtest'><td>aria-rowindex NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "result atk</em>table<em>cell</em>get_position() contains row=2" failed <br />
 <strong>Actual value:</strong> (1, row=0, column=0) <br />
@@ -260,18 +228,13 @@
 <a href="https://webkit.org/b/171176">https://webkit.org/b/171176</a>: [NEW] [ATK] atk_table_cell_get_position() should return values of aria-rowindex and aria-colindex, if present <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr id='subtest-95-1' class='subtest'><td>aria-rowindex NEW 1</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>GC02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>WK02:</td><td> assert_true: ERROR: No results reported from ATTA;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-103'><td><a href='http://www.w3c-test.org/core-aam/aria-sort_none-manual.html' target='_blank'>/core-aam/aria-sort_none-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
+<tr class='test' id='test-file-103'><td><a href='http://www.w3c-test.org/core-aam/aria-sort_none-manual.html' target='_blank'>/core-aam/aria-sort_none-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td></tr>
 <tr id='subtest-103-0' class='subtest'><td>aria-sort=none</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>WK01:</td><td> assert_true: "property objectAttributes contains sort:none" failed <br />
 <strong>Actual value:</strong> ['computed-role:columnheader', 'xml-roles:columnheader', 'readonly:false', 'html-id:test', 'tag:div', 'toolkit:WebKitGtk'] <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-110'><td><a href='http://www.w3c-test.org/core-aam/aria-valuetext_value_changes-manual.html' target='_blank'>/core-aam/aria-valuetext_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-110'><td><a href='http://www.w3c-test.org/core-aam/aria-valuetext_value_changes-manual.html' target='_blank'>/core-aam/aria-valuetext_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-110-0' class='subtest'><td>aria-valuetext value changes</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "event type is object:property-change:accessible-value" failed <br />
 ;  expected true got false</td></tr>
@@ -282,7 +245,7 @@
 <tr class='message'><td class='ua'>WK01:</td><td> assert_true: "event type is object:property-change:accessible-value" failed <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-133'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_math-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-133'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_math-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-133-0' class='subtest'><td>Exclude presentational children of math</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
@@ -300,7 +263,7 @@
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-134'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-134'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-134-0' class='subtest'><td>Exclude presentational children of menuitemcheckbox NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
@@ -318,7 +281,7 @@
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-135'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-135-0' class='subtest'><td>Exclude presentational children of menuitemradio NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />
@@ -336,7 +299,7 @@
 <strong>Actual value:</strong> true <br />
 ;  expected true got false</td></tr>
 </table></td></tr>
-<tr class='test' id='test-file-140'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_separator-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_separator-manual.html</a> <small>(1/1, 100.00%, 0.40% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='test' id='test-file-140'><td><a href='http://www.w3c-test.org/core-aam/exclude_presentational_children_of_separator-manual.html' target='_blank'>/core-aam/exclude_presentational_children_of_separator-manual.html</a> <small>(1/1, 100.00%, 0.41% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-140-0' class='subtest'><td>Exclude presentational children of separator</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='6'><table><tr class='message'><td class='ua'>FF01:</td><td> assert_true: "property accessible is false" failed <br />
 <strong>Actual value:</strong> true <br />


### PR DESCRIPTION
Regenerate results after fixing empty-assertion issue in test generation
in wai-aria/tools/make_tests.pl from web-platform-tests.