### PR TITLE
Core-AAM: Updated results after manual verification of aria-owns

### DIFF
--- a/core-aam/README.md
+++ b/core-aam/README.md
@@ -40,7 +40,7 @@ Index of Implementations
 * FF01 - Firefox on Linux using ATK - DEMONSTRATES IMPLEMENTABILITY
   * email: jdiggs@igalia.com
   * link: <http://www.mozilla.org>
-  * status: 78% of mappings successfully implemented (185/237)
+  * status: 79% of mappings successfully implemented (188/237)
 
 * WK02 - WebKit/Safari on macOS using AX API - DEMONSTRATES IMPLEMENTABILITY
   * email: jdiggs@igalia.com
@@ -60,7 +60,7 @@ Index of Implementations
 * FF03 - Firefox on Windows using IAccessible2 - NEEDS EVALUATION
   * email: jongund@illinois.edu
   * link: <http://www.mozilla.org>
-  * status: 103 PASS, 44 FAIL, 12 "Unhandled rejection" ERROR
+  * status: 106 PASS, 41 FAIL, 9 "Unhandled rejection" ERROR
 
 * GC03 - Chrome on Windows using IAccessible2 - NEEDS EVALUATION
   * email: jongund@illinois.edu

--- a/core-aam/all.html
+++ b/core-aam/all.html
@@ -869,32 +869,26 @@ ERROR: Object not found<br />
 <tr class='test' id='test-file-75'><td><a href='http://www.w3c-test.org/core-aam/aria-orientation_vertical-manual.html' target='_blank'>/core-aam/aria-orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-75-0' class='subtest'><td>aria-orientation=vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-76'><td><a href='http://www.w3c-test.org/core-aam/aria-owns_may_need_manual_verification-manual.html' target='_blank'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='ERROR'>ERROR</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-76-0' class='subtest'><td>aria-owns may need manual verification</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='11'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>PARENT</em>OF is [owned1,owned2]" failed<br />
-<strong>Actual value:</strong> []<br />
-;  expected true got false</td></tr>
+<tr id='subtest-76-0' class='subtest'><td>aria-owns may need manual verification</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='11'><table><tr class='message'><td class='ua'>FF01:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>FF02:</td><td> assert_true: "property AXOwns is [owned1,owned2]" failed<br />
 <strong>Actual value:</strong> None<br />
 ;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC02:</td><td> assert_true: "property AXOwns is [owned1,owned2]" failed<br />
 <strong>Actual value:</strong> None<br />
 ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 <tr class='message'><td class='ua'>ME05:</td><td> tbd is supposed to be owned1 but was UNKNOWN, and tbd is supposed to be owned2 but was UNKNOWN</td></tr>
 </table></td></tr>
-<tr id='subtest-76-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='11'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed<br />
-<strong>Actual value:</strong> []<br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr id='subtest-76-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='11'><table><tr class='message'><td class='ua'>FF01:</td><td> Relationship not needed because user agent modifies tree</td></tr>
+<tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
-<tr id='subtest-76-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr class='messages'><td colspan='11'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed<br />
-<strong>Actual value:</strong> []<br />
-;  expected true got false</td></tr>
-<tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr id='subtest-76-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='messages'><td colspan='11'><table><tr class='message'><td class='ua'>FF01:</td><td> Relationship not needed because user agent modifies tree</td></tr>
+<tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-77'><td><a href='http://www.w3c-test.org/core-aam/aria-placeholder_new-manual.html' target='_blank'>/core-aam/aria-placeholder_new-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='NOTRUN'>NOTRUN</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>

--- a/core-aam/atk/FF01.json
+++ b/core-aam/atk/FF01.json
@@ -1011,18 +1011,18 @@
       "subtests": [
         {
           "name": "aria-owns may need manual verification",
-          "status": "FAIL",
-          "message": "assert_true: \"relation RELATION_NODE_PARENT_OF is [owned1,owned2]\" failed   \n**Actual value:** []  \n;  expected true got false"
+          "status": "PASS",
+          "message": "Relationship not needed because user agent modifies tree"
         },
         {
           "name": "aria-owns may need manual verification 1",
-          "status": "FAIL",
-          "message": "assert_true: \"relation RELATION_NODE_CHILD_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
+          "status": "PASS",
+          "message": "Relationship not needed because user agent modifies tree"
         },
         {
           "name": "aria-owns may need manual verification 2",
-          "status": "FAIL",
-          "message": "assert_true: \"relation RELATION_NODE_CHILD_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
+          "status": "PASS",
+          "message": "Relationship not needed because user agent modifies tree"
         }
       ],
       "status": "OK",

--- a/core-aam/atk/all.html
+++ b/core-aam/atk/all.html
@@ -431,20 +431,14 @@ ERROR: Object not found<br />
 <tr class='test' id='test-file-71'><td><a href='http://www.w3c-test.org/core-aam/aria-orientation_vertical-manual.html' target='_blank'>/core-aam/aria-orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-71-0' class='subtest'><td>aria-orientation=vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-72'><td><a href='http://www.w3c-test.org/core-aam/aria-owns_may_need_manual_verification-manual.html' target='_blank'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-72-0' class='subtest'><td>aria-owns may need manual verification</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>PARENT</em>OF is [owned1,owned2]" failed<br />
-<strong>Actual value:</strong> []<br />
-;  expected true got false</td></tr>
+<tr id='subtest-72-0' class='subtest'><td>aria-owns may need manual verification</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 </table></td></tr>
-<tr id='subtest-72-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed<br />
-<strong>Actual value:</strong> []<br />
-;  expected true got false</td></tr>
+<tr id='subtest-72-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 </table></td></tr>
-<tr id='subtest-72-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed<br />
-<strong>Actual value:</strong> []<br />
-;  expected true got false</td></tr>
+<tr id='subtest-72-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-73'><td><a href='http://www.w3c-test.org/core-aam/aria-placeholder_new-manual.html' target='_blank'>/core-aam/aria-placeholder_new-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-73-0' class='subtest'><td>aria-placeholder NEW</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>

--- a/core-aam/atk/complete-fails.html
+++ b/core-aam/atk/complete-fails.html
@@ -12,7 +12,7 @@
         <h1>Core AAM 1.1 - ATK: Complete Failures</h1>
       </header>
       
-      <p><strong>Completely failed files</strong>: 52; <strong>Completely failed subtests</strong>: 2; <strong>Failure level</strong>: 2/237 (0.84%)</p>
+      <p><strong>Completely failed files</strong>: 51; <strong>Completely failed subtests</strong>: 2; <strong>Failure level</strong>: 2/237 (0.84%)</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/core-aam/aria-setsize_-1_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
 <li><a href='#test-file-1'>/core-aam/definition-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>

--- a/core-aam/atk/consolidated.json
+++ b/core-aam/atk/consolidated.json
@@ -1862,43 +1862,40 @@
         "aria-owns may need manual verification": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
             "WK01": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"relation RELATION_NODE_PARENT_OF is [owned1,owned2]\" failed   \n**Actual value:** []  \n;  expected true got false"
+            "FF01": "Relationship not needed because user agent modifies tree"
           },
           "totals": {
-            "FAIL": 1,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "aria-owns may need manual verification 1": {
           "stNum": 1,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
             "WK01": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"relation RELATION_NODE_CHILD_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
+            "FF01": "Relationship not needed because user agent modifies tree"
           },
           "totals": {
-            "FAIL": 1,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "aria-owns may need manual verification 2": {
           "stNum": 2,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
             "WK01": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"relation RELATION_NODE_CHILD_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false"
+            "FF01": "Relationship not needed because user agent modifies tree"
           },
           "totals": {
-            "FAIL": 1,
-            "PASS": 1
+            "PASS": 2
           }
         }
       }

--- a/core-aam/atk/less-than-2.html
+++ b/core-aam/atk/less-than-2.html
@@ -12,7 +12,7 @@
         <h1>Core AAM 1.1 - ATK: Less Than 2 Passes</h1>
       </header>
       
-      <p><strong>Test files without 2 passes</strong>: 52; <strong>Subtests without 2 passes: </strong>56; <strong>Failure level</strong>: 56/237 (23.63%)</p>
+      <p><strong>Test files without 2 passes</strong>: 51; <strong>Subtests without 2 passes: </strong>53; <strong>Failure level</strong>: 53/237 (22.36%)</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/core-aam/aria-atomic_true-manual.html</a> <small>(1/2, 50.00%, 0.42% of total)</small></li>
 <li><a href='#test-file-1'>/core-aam/aria-colcount_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
@@ -22,50 +22,49 @@
 <li><a href='#test-file-5'>/core-aam/aria-hidden_true-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
 <li><a href='#test-file-6'>/core-aam/aria-hidden_true_when_element_is_focused_or_fires_event_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
 <li><a href='#test-file-7'>/core-aam/aria-orientation_undefined_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-8'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(3/3, 100.00%, 1.27% of total)</small></li>
-<li><a href='#test-file-9'>/core-aam/aria-placeholder_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-10'>/core-aam/aria-pressed_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-11'>/core-aam/aria-readonly_is_unspecified_on_gridcell_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-12'>/core-aam/aria-readonly_true_on_checkbox-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-13'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(2/2, 100.00%, 0.84% of total)</small></li>
-<li><a href='#test-file-14'>/core-aam/aria-readonly_true_on_textbox-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-15'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.84% of total)</small></li>
-<li><a href='#test-file-16'>/core-aam/aria-relevant-manual.html</a> <small>(1/2, 50.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-17'>/core-aam/aria-rowcount_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-18'>/core-aam/aria-rowindex_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-19'>/core-aam/aria-rowspan_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-20'>/core-aam/aria-setsize_-1_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-21'>/core-aam/banner-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-22'>/core-aam/complementary-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-23'>/core-aam/contentinfo-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-24'>/core-aam/definition-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-25'>/core-aam/exclude_presentational_children_of_button-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-26'>/core-aam/exclude_presentational_children_of_checkbox_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-27'>/core-aam/exclude_presentational_children_of_img-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-28'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-29'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-30'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-31'>/core-aam/exclude_presentational_children_of_option_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-32'>/core-aam/exclude_presentational_children_of_progressbar-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-33'>/core-aam/exclude_presentational_children_of_radio_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-34'>/core-aam/exclude_presentational_children_of_scrollbar-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-35'>/core-aam/exclude_presentational_children_of_separator-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-36'>/core-aam/exclude_presentational_children_of_slider-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-37'>/core-aam/exclude_presentational_children_of_switch_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-38'>/core-aam/exclude_presentational_children_of_tab_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-39'>/core-aam/form-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-40'>/core-aam/img-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-41'>/core-aam/log-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-42'>/core-aam/main-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-43'>/core-aam/marquee-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-44'>/core-aam/math-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-45'>/core-aam/menu-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-46'>/core-aam/menu_child_of_menu_item-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-47'>/core-aam/menubar-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-48'>/core-aam/navigation-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-49'>/core-aam/rowgroup-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-50'>/core-aam/search-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
-<li><a href='#test-file-51'>/core-aam/timer-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-8'>/core-aam/aria-placeholder_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-9'>/core-aam/aria-pressed_value_changes-manual.html</a> <small>(1/2, 50.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-10'>/core-aam/aria-readonly_is_unspecified_on_gridcell_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-11'>/core-aam/aria-readonly_true_on_checkbox-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-12'>/core-aam/aria-readonly_true_on_radiogroup-manual.html</a> <small>(2/2, 100.00%, 0.84% of total)</small></li>
+<li><a href='#test-file-13'>/core-aam/aria-readonly_true_on_textbox-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-14'>/core-aam/aria-readonly_value_changes-manual.html</a> <small>(2/2, 100.00%, 0.84% of total)</small></li>
+<li><a href='#test-file-15'>/core-aam/aria-relevant-manual.html</a> <small>(1/2, 50.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-16'>/core-aam/aria-rowcount_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-17'>/core-aam/aria-rowindex_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-18'>/core-aam/aria-rowspan_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-19'>/core-aam/aria-setsize_-1_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-20'>/core-aam/banner-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-21'>/core-aam/complementary-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-22'>/core-aam/contentinfo-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-23'>/core-aam/definition-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-24'>/core-aam/exclude_presentational_children_of_button-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-25'>/core-aam/exclude_presentational_children_of_checkbox_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-26'>/core-aam/exclude_presentational_children_of_img-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-27'>/core-aam/exclude_presentational_children_of_math-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-28'>/core-aam/exclude_presentational_children_of_menuitemcheckbox_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-29'>/core-aam/exclude_presentational_children_of_menuitemradio_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-30'>/core-aam/exclude_presentational_children_of_option_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-31'>/core-aam/exclude_presentational_children_of_progressbar-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-32'>/core-aam/exclude_presentational_children_of_radio_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-33'>/core-aam/exclude_presentational_children_of_scrollbar-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-34'>/core-aam/exclude_presentational_children_of_separator-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-35'>/core-aam/exclude_presentational_children_of_slider-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-36'>/core-aam/exclude_presentational_children_of_switch_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-37'>/core-aam/exclude_presentational_children_of_tab_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-38'>/core-aam/form-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-39'>/core-aam/img-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-40'>/core-aam/log-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-41'>/core-aam/main-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-42'>/core-aam/marquee-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-43'>/core-aam/math-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-44'>/core-aam/menu-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-45'>/core-aam/menu_child_of_menu_item-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-46'>/core-aam/menubar-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-47'>/core-aam/navigation-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-48'>/core-aam/rowgroup-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-49'>/core-aam/search-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
+<li><a href='#test-file-50'>/core-aam/timer-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF01</th><th>WK01</th></tr></thead>
@@ -122,22 +121,6 @@ ERROR: Object not found<br />
 <tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "property states doesNotContain STATE</em>VERTICAL" failed<br />
 <strong>Actual value:</strong> ['STATE_ENABLED', 'STATE_OPAQUE', 'STATE_SENSITIVE', 'STATE_SHOWING', 'STATE_VERTICAL', 'STATE_VISIBLE', 'STATE_SELECTABLE_TEXT']<br />
 <a href="https://bugzil.la/1357042">https://bugzil.la/1357042</a>: [RESOLVED FIXED] Implement or update support for exposure of aria-orientation<br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-72'><td><a href='http://www.w3c-test.org/core-aam/aria-owns_may_need_manual_verification-manual.html' target='_blank'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(3/3, 100.00%, 1.27% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-72-0' class='subtest'><td>aria-owns may need manual verification</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>PARENT</em>OF is [owned1,owned2]" failed<br />
-<strong>Actual value:</strong> []<br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr id='subtest-72-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed<br />
-<strong>Actual value:</strong> []<br />
-;  expected true got false</td></tr>
-</table></td></tr>
-<tr id='subtest-72-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF01:</td><td> assert<em>true: "relation RELATION</em>NODE<em>CHILD</em>OF is [test]" failed<br />
-<strong>Actual value:</strong> []<br />
 ;  expected true got false</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-73'><td><a href='http://www.w3c-test.org/core-aam/aria-placeholder_new-manual.html' target='_blank'>/core-aam/aria-placeholder_new-manual.html</a> <small>(1/1, 100.00%, 0.42% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>

--- a/core-aam/consolidated.json
+++ b/core-aam/consolidated.json
@@ -3700,9 +3700,9 @@
         "aria-owns may need manual verification": {
           "stNum": 0,
           "byUA": {
-            "FF01": "FAIL",
+            "FF01": "PASS",
             "FF02": "FAIL",
-            "FF03": "FAIL",
+            "FF03": "PASS",
             "GC02": "FAIL",
             "GC03": "FAIL",
             "ME05": "FAIL",
@@ -3710,54 +3710,54 @@
             "WK02": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"relation RELATION_NODE_PARENT_OF is [owned1,owned2]\" failed   \n**Actual value:** []  \n;  expected true got false",
+            "FF01": "Relationship not needed because user agent modifies tree",
             "FF02": "assert_true: \"property AXOwns is [owned1,owned2]\" failed   \n**Actual value:** None  \n;  expected true got false",
-            "FF03": "promise_test: Unhandled rejection with value: object \"[object Object]\"",
+            "FF03": "Relationship not needed because user agent modifies tree",
             "GC02": "assert_true: \"property AXOwns is [owned1,owned2]\" failed   \n**Actual value:** None  \n;  expected true got false",
             "GC03": "promise_test: Unhandled rejection with value: object \"[object Object]\"",
             "ME05": "tbd is supposed to be owned1 but was UNKNOWN, and tbd is supposed to be owned2 but was UNKNOWN"
           },
           "totals": {
-            "FAIL": 6,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 4
           }
         },
         "aria-owns may need manual verification 1": {
           "stNum": 1,
           "byUA": {
-            "FF01": "FAIL",
-            "FF03": "FAIL",
+            "FF01": "PASS",
+            "FF03": "PASS",
             "GC03": "FAIL",
             "ME05": "PASS",
             "WK01": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"relation RELATION_NODE_CHILD_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false",
-            "FF03": "promise_test: Unhandled rejection with value: object \"[object Object]\"",
+            "FF01": "Relationship not needed because user agent modifies tree",
+            "FF03": "Relationship not needed because user agent modifies tree",
             "GC03": "promise_test: Unhandled rejection with value: object \"[object Object]\""
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 1
           }
         },
         "aria-owns may need manual verification 2": {
           "stNum": 2,
           "byUA": {
-            "FF01": "FAIL",
-            "FF03": "FAIL",
+            "FF01": "PASS",
+            "FF03": "PASS",
             "GC03": "FAIL",
             "ME05": "PASS",
             "WK01": "PASS"
           },
           "UAmessage": {
-            "FF01": "assert_true: \"relation RELATION_NODE_CHILD_OF is [test]\" failed   \n**Actual value:** []  \n;  expected true got false",
-            "FF03": "promise_test: Unhandled rejection with value: object \"[object Object]\"",
+            "FF01": "Relationship not needed because user agent modifies tree",
+            "FF03": "Relationship not needed because user agent modifies tree",
             "GC03": "promise_test: Unhandled rejection with value: object \"[object Object]\""
           },
           "totals": {
-            "FAIL": 3,
-            "PASS": 2
+            "PASS": 4,
+            "FAIL": 1
           }
         }
       }

--- a/core-aam/ia2/FF03.json
+++ b/core-aam/ia2/FF03.json
@@ -884,18 +884,18 @@
       "subtests": [
         {
           "name": "aria-owns may need manual verification",
-          "status": "FAIL",
-          "message": "promise_test: Unhandled rejection with value: object \"[object Object]\""
+          "status": "PASS",
+          "message": "Relationship not needed because user agent modifies tree"
         },
         {
           "name": "aria-owns may need manual verification 1",
-          "status": "FAIL",
-          "message": "promise_test: Unhandled rejection with value: object \"[object Object]\""
+          "status": "PASS",
+          "message": "Relationship not needed because user agent modifies tree"
         },
         {
           "name": "aria-owns may need manual verification 2",
-          "status": "FAIL",
-          "message": "promise_test: Unhandled rejection with value: object \"[object Object]\""
+          "status": "PASS",
+          "message": "Relationship not needed because user agent modifies tree"
         }
       ],
       "status": "OK",

--- a/core-aam/ia2/all.html
+++ b/core-aam/ia2/all.html
@@ -352,16 +352,16 @@
 <tr class='test' id='test-file-53'><td><a href='http://www.w3c-test.org/core-aam/aria-orientation_vertical-manual.html' target='_blank'>/core-aam/aria-orientation_vertical-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-53-0' class='subtest'><td>aria-orientation=vertical</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/core-aam/aria-owns_may_need_manual_verification-manual.html' target='_blank'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a></td><td class='OK'>OK</td><td class='ERROR'>ERROR</td></tr>
-<tr id='subtest-54-0' class='subtest'><td>aria-owns may need manual verification</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr id='subtest-54-0' class='subtest'><td>aria-owns may need manual verification</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
-<tr id='subtest-54-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr id='subtest-54-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
-<tr id='subtest-54-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr id='subtest-54-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/core-aam/aria-placeholder_new-manual.html' target='_blank'>/core-aam/aria-placeholder_new-manual.html</a></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>

--- a/core-aam/ia2/complete-fails.html
+++ b/core-aam/ia2/complete-fails.html
@@ -12,7 +12,7 @@
         <h1>Core AAM 1.1 - IAccessible2: Complete Failures</h1>
       </header>
       
-      <p><strong>Completely failed files</strong>: 71; <strong>Completely failed subtests</strong>: 39; <strong>Failure level</strong>: 39/147 (26.53%)</p>
+      <p><strong>Completely failed files</strong>: 71; <strong>Completely failed subtests</strong>: 36; <strong>Failure level</strong>: 36/147 (24.49%)</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/core-aam/aria-colcount_new-manual.html</a> <small>(1/2, 50.00%, 0.68% of total)</small></li>
 <li><a href='#test-file-1'>/core-aam/aria-colindex_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
@@ -22,33 +22,32 @@
 <li><a href='#test-file-5'>/core-aam/aria-grabbed_value_changes-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
 <li><a href='#test-file-6'>/core-aam/aria-haspopup_false-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
 <li><a href='#test-file-7'>/core-aam/aria-hidden_value_changes-manual.html</a> <small>(2/2, 100.00%, 1.36% of total)</small></li>
-<li><a href='#test-file-8'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(3/3, 100.00%, 2.04% of total)</small></li>
-<li><a href='#test-file-9'>/core-aam/aria-placeholder_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-10'>/core-aam/aria-readonly_false-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-11'>/core-aam/aria-rowcount_new-manual.html</a> <small>(1/2, 50.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-12'>/core-aam/aria-rowindex_new-manual.html</a> <small>(1/2, 50.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-13'>/core-aam/aria-rowspan_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-14'>/core-aam/banner-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-15'>/core-aam/complementary-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-16'>/core-aam/contentinfo-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-17'>/core-aam/grid-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-18'>/core-aam/link-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-19'>/core-aam/listbox_not_owned_by_or_child_of_combobox-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-20'>/core-aam/listbox_owned_by_or_child_of_combobox-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-21'>/core-aam/main-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-22'>/core-aam/menu-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-23'>/core-aam/menu_child_of_menu_item-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-24'>/core-aam/menubar-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-25'>/core-aam/navigation-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-26'>/core-aam/none_used_on_table_element_with_td_children_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-27'>/core-aam/none_used_on_ul_element_with_li_children_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-28'>/core-aam/presentation_used_on_table_element_with_td_children_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-29'>/core-aam/presentation_used_on_ul_element_with_li_children_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-30'>/core-aam/search-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-31'>/core-aam/tablist-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-32'>/core-aam/term_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-33'>/core-aam/tree-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
-<li><a href='#test-file-34'>/core-aam/treegrid-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-8'>/core-aam/aria-placeholder_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-9'>/core-aam/aria-readonly_false-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-10'>/core-aam/aria-rowcount_new-manual.html</a> <small>(1/2, 50.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-11'>/core-aam/aria-rowindex_new-manual.html</a> <small>(1/2, 50.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-12'>/core-aam/aria-rowspan_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-13'>/core-aam/banner-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-14'>/core-aam/complementary-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-15'>/core-aam/contentinfo-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-16'>/core-aam/grid-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-17'>/core-aam/link-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-18'>/core-aam/listbox_not_owned_by_or_child_of_combobox-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-19'>/core-aam/listbox_owned_by_or_child_of_combobox-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-20'>/core-aam/main-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-21'>/core-aam/menu-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-22'>/core-aam/menu_child_of_menu_item-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-23'>/core-aam/menubar-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-24'>/core-aam/navigation-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-25'>/core-aam/none_used_on_table_element_with_td_children_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-26'>/core-aam/none_used_on_ul_element_with_li_children_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-27'>/core-aam/presentation_used_on_table_element_with_td_children_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-28'>/core-aam/presentation_used_on_ul_element_with_li_children_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-29'>/core-aam/search-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-30'>/core-aam/tablist-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-31'>/core-aam/term_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-32'>/core-aam/tree-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
+<li><a href='#test-file-33'>/core-aam/treegrid-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></li>
 </ol>
       <table class='table persist-area'>
         <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>FF03</th><th>GC03</th></tr></thead>
@@ -99,19 +98,6 @@
 <tr id='subtest-34-1' class='subtest'><td>aria-hidden value changes 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
 <tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> assert<em>true: "event type is IA2</em>EVENT<em>OBJECT</em>ATTRIBUTE_CHANGED" failed ;  expected true got false</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> assert<em>true: "event type is IA2</em>EVENT<em>OBJECT</em>ATTRIBUTE_CHANGED" failed ;  expected true got false</td></tr>
-</table></td></tr>
-<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/core-aam/aria-owns_may_need_manual_verification-manual.html' target='_blank'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(3/3, 100.00%, 2.04% of total)</small></td><td class='OK'>OK</td><td class='ERROR'>ERROR</td></tr>
-<tr id='subtest-54-0' class='subtest'><td>aria-owns may need manual verification</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
-<tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
-</table></td></tr>
-<tr id='subtest-54-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
-<tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
-</table></td></tr>
-<tr id='subtest-54-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
-<tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/core-aam/aria-placeholder_new-manual.html' target='_blank'>/core-aam/aria-placeholder_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
 <tr id='subtest-55-0' class='subtest'><td>aria-placeholder NEW</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>

--- a/core-aam/ia2/consolidated.json
+++ b/core-aam/ia2/consolidated.json
@@ -1521,43 +1521,46 @@
         "aria-owns may need manual verification": {
           "stNum": 0,
           "byUA": {
-            "FF03": "FAIL",
+            "FF03": "PASS",
             "GC03": "FAIL"
           },
           "UAmessage": {
-            "FF03": "promise_test: Unhandled rejection with value: object \"[object Object]\"",
+            "FF03": "Relationship not needed because user agent modifies tree",
             "GC03": "promise_test: Unhandled rejection with value: object \"[object Object]\""
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 1,
+            "FAIL": 1
           }
         },
         "aria-owns may need manual verification 1": {
           "stNum": 1,
           "byUA": {
-            "FF03": "FAIL",
+            "FF03": "PASS",
             "GC03": "FAIL"
           },
           "UAmessage": {
-            "FF03": "promise_test: Unhandled rejection with value: object \"[object Object]\"",
+            "FF03": "Relationship not needed because user agent modifies tree",
             "GC03": "promise_test: Unhandled rejection with value: object \"[object Object]\""
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 1,
+            "FAIL": 1
           }
         },
         "aria-owns may need manual verification 2": {
           "stNum": 2,
           "byUA": {
-            "FF03": "FAIL",
+            "FF03": "PASS",
             "GC03": "FAIL"
           },
           "UAmessage": {
-            "FF03": "promise_test: Unhandled rejection with value: object \"[object Object]\"",
+            "FF03": "Relationship not needed because user agent modifies tree",
             "GC03": "promise_test: Unhandled rejection with value: object \"[object Object]\""
           },
           "totals": {
-            "FAIL": 2
+            "PASS": 1,
+            "FAIL": 1
           }
         }
       }

--- a/core-aam/ia2/less-than-2.html
+++ b/core-aam/ia2/less-than-2.html
@@ -237,16 +237,16 @@
 <tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>GC03:</td><td> assert_true: "property objectAttributes contains container-live:off" failed ;  expected true got false</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/core-aam/aria-owns_may_need_manual_verification-manual.html' target='_blank'>/core-aam/aria-owns_may_need_manual_verification-manual.html</a> <small>(3/3, 100.00%, 2.04% of total)</small></td><td class='OK'>OK</td><td class='ERROR'>ERROR</td></tr>
-<tr id='subtest-54-0' class='subtest'><td>aria-owns may need manual verification</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr id='subtest-54-0' class='subtest'><td>aria-owns may need manual verification</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
-<tr id='subtest-54-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr id='subtest-54-1' class='subtest'><td>aria-owns may need manual verification 1</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
-<tr id='subtest-54-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
+<tr id='subtest-54-2' class='subtest'><td>aria-owns may need manual verification 2</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='messages'><td colspan='3'><table><tr class='message'><td class='ua'>FF03:</td><td> Relationship not needed because user agent modifies tree</td></tr>
 <tr class='message'><td class='ua'>GC03:</td><td> promise_test: Unhandled rejection with value: object "[object Object]"</td></tr>
 </table></td></tr>
 <tr class='test' id='test-file-55'><td><a href='http://www.w3c-test.org/core-aam/aria-placeholder_new-manual.html' target='_blank'>/core-aam/aria-placeholder_new-manual.html</a> <small>(1/1, 100.00%, 0.68% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td></tr>


### PR DESCRIPTION
The Core AAM states that "user agents MAY expose the elements that
are referenced by this property as children of the current element."
The relationship mappings which follow (and are being tested here)
are the mappings when "the accessibility tree is not modified."
Because Firefox correctly modifies the accessibility tree, these
tests pass.