### PR TITLE
html 5.3 implementation report updates

### DIFF
--- a/html53/implementation-report.html
+++ b/html53/implementation-report.html
@@ -28,11 +28,11 @@ width="72"></a></p>
 and <a href="https://w3.org/tr/html53/">HTML5.3</a>. It is intended to demonstrate sufficient interoperability to
 justify moving HTML5.3 from Candidate Recommendation
 <a href="https://www.w3.org/2018/Process-20180201/#rec-pr">as required by W3C Process</a>.</p>
-  
-<p>After that time it is unlikely to be updated, and people interested in the support of HTML features should instead look at the many 
+
+<p>After that time it is unlikely to be updated, and people interested in the support of HTML features should instead look at the many
   resources on the Web that try to provide that information in an up-to-date form.</p>
-  
-<p>Last updated: 8 May 2018.</p>
+
+<p>Last updated: 21 May 2018.</p>
 
 <p>Implementation information is documented in the relevant Github issue, Pull Request (PR), or documentation for developers.</p>
 
@@ -216,7 +216,7 @@ justify moving HTML5.3 from Candidate Recommendation
 
 <tr>
 <th><a href="https://github.com/w3c/html/pull/1323">add <code>customElements</code> property</a> to
-<a href="">the <code>Window</code> Object/a></th>
+<a href="">the <code>Window</code> Object</a></th>
 <td class="pass">Pass</td>
 <td class="notTested">?</td>
 <td class="pass">Pass</td>
@@ -224,7 +224,7 @@ justify moving HTML5.3 from Candidate Recommendation
 <td class="notTested">?</td>
 <td>Tested manually with the console</td>
 </tr>
-  
+
 <tr>
 <th><a href="https://github.com/w3c/html/pull/1204"><code>caption</code> end tag</a> is not required</th>
 <td class="pass">Pass</td>
@@ -280,12 +280,12 @@ justify moving HTML5.3 from Candidate Recommendation
 
 <tr>
 <th><a href="https://github.com/w3c/html/pull/1225">Removed "monkeypatch" for File API</a></th>
-<td class="notTested">?</td>
-<td class="notTested">?</td>
-<td class="notTested">?</td>
-<td class="notTested">?</td>
-<td class="notTested">?</td>
-<td>Scott</td>
+<td class="notTested">-</td>
+<td class="notTested">-</td>
+<td class="notTested">-</td>
+<td class="notTested">-</td>
+<td class="notTested">-</td>
+<td>removed from spec due to resolution of <a href="https://github.com/w3c/FileAPI/issues/32">w3c/FileAPI#32</a> and updated specification defined in <a href="https://w3c.github.io/FileAPI/">FileAPI</a>.</td>
 </tr>
 </tbody>
 </table>
@@ -320,15 +320,6 @@ justify moving HTML5.3 from Candidate Recommendation
 <td>Xiaoqian (note the link in the changelog to this PR is broken)</td>
 </tr>
 
-<tr>
-<th><a href="https://github.com/w3c/html/pull/1133">Resolves differences between HTML and ARIA specifications</a></th>
-<td class="notTested">?</td>
-<td class="notTested">?</td>
-<td class="notTested">?</td>
-<td class="notTested">?</td>
-<td class="notTested">?</td>
-<td>Scott</td>
-</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
update last updated date

fix broken end tag for `</a>` element

add note about removal of monkeypatch for file API

removal of diffs between HTML/ARIA specs as these were editorial updates.