### PR TITLE
Core-AAM: Remove links to results files

### DIFF
--- a/core-aam-1.2/README.md
+++ b/core-aam-1.2/README.md
@@ -3,9 +3,8 @@ Core Accessibility API Mappings 1.2: Test Results
 
 Implementation Report
 ---------------------
-* [all](all.html)
-* [less than two](less-than-2.html)
-* [complete failures](complete-fails.html)
+At this time we are still writing tests, obtaining results, and seeking
+missing implementations.
 
 Supported Platform Accessibility APIs
 -------------------------------------


### PR DESCRIPTION
The ARIA WG is still writing tests, obtaining results, and seeking
missing implementations. Having only some of the tests and results
which are not fully up-to-date can give the impression that we are
not pursuing full coverage of new features.